### PR TITLE
Moving the lock to be the first field of InjectorPP to fix dropping racing issue

### DIFF
--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -421,9 +421,9 @@ impl Drop for CallCountVerifier {
 /// A high-level type that holds patch guards so that when it goes out of scope,
 /// the original function code is automatically restored.
 pub struct InjectorPP {
+    _lock: MutexGuard<'static, ()>,
     guards: Vec<PatchGuard>,
     verifiers: Vec<CallCountVerifier>,
-    _lock: MutexGuard<'static, ()>,
 }
 
 impl InjectorPP {

--- a/tests/will_return.rs
+++ b/tests/will_return.rs
@@ -8,7 +8,7 @@ fn complex_generic_multiple_types_func_return_false<A, B, C>(_a: A, _b: B, _c: C
     return false;
 }
 
-/*#[test]
+#[test]
 fn test_will_return_boolean_when_in_scope_should_restore() {
     assert_eq!(returns_false(), false);
 
@@ -25,7 +25,7 @@ fn test_will_return_boolean_when_in_scope_should_restore() {
     let restored = returns_false();
 
     assert_eq!(restored, false);
-}*/
+}
 
 #[test]
 fn test_will_return_boolean_when_fake_return_true_should_success() {


### PR DESCRIPTION
In current implementation, `_lock` is declared last and it is dropped before `PatchGuards` restore the original bytes, so another test can slip in and re-patch underneath. The intermittent failure comes from two tests racing on the same function.

The fix is to hold the lock through all of the guard drops. Simply move _lock to be the first field of `InjectorPP` so it’s dropped last


Fix #14 and #8 