### PR TITLE
Update README.md to only add injectorpp as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This approach eliminates the need to make a trait solely for testing purposes. I
 Add `injectorpp` to the `Cargo.toml`:
 
 ```toml
-[dependencies]
+[dev-dependencies]
 injectorpp = "0.3.3"
 ```
 


### PR DESCRIPTION
Since injectorpp is only used for testing, it does not need to be part of the normal code. Adding injectorpp as a dev dependency is reasonable.