### PR TITLE
Increase safety for public api

### DIFF
--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -103,7 +103,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With when, assign, and returns (no times).
     (
@@ -122,7 +122,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With when and returns, times, but no assign.
     (
@@ -146,7 +146,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With when and returns (no times, no assign).
     (
@@ -163,7 +163,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With assign, returns and times
     (
@@ -188,7 +188,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With assign and returns
     (
@@ -206,7 +206,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With times and returns
     (
@@ -229,7 +229,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With returns only.
     (
@@ -245,7 +245,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> $ret) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
 
     // === UNIT RETURNING FUNCTIONS (-> ()) ===
@@ -272,7 +272,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With when and times (no assign).
     (
@@ -295,7 +295,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With when and assign (no times).
     (
@@ -312,7 +312,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With assign only
     (
@@ -328,7 +328,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With assign and times
     (
@@ -353,7 +353,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With times only (when defaults to true, no assign).
     (
@@ -375,7 +375,7 @@ macro_rules! fake {
              }
          }
          let raw_ptr = (fake as fn($($arg_ty),*) -> ()) as *const ();
-         (raw_ptr, verifier)
+         (unsafe { FuncPtr::new(raw_ptr) }, verifier)
     }};
     // With neither (no when, no times, no assign, no returns).
     (
@@ -659,11 +659,11 @@ impl WhenCalledBuilder<'_> {
     /// `assign``: // Optional. Use to set values to reference variables of the function to fake.
     /// `returns``: // Required for the function has return. Specify what the return value should be.
     /// `times``: // Optional. How many times the function should be called. If the value is not satisfied at the end of the test, the test will fail.
-    pub fn will_execute(self, fake_pair: (*const (), CallCountVerifier)) {
+    pub fn will_execute(self, fake_pair: (FuncPtr, CallCountVerifier)) {
         let (fake_func, verifier) = fake_pair;
         self.lib.verifiers.push(verifier);
         //self.will_execute_raw(func!(fake_func));
-        self.will_execute_raw(unsafe { FuncPtr::new(fake_func) });
+        self.will_execute_raw(fake_func);
     }
 
     /// Fake the target function to always return a fixed boolean value.

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -64,9 +64,10 @@ macro_rules! func {
     }};
 
     // Case 2: Non-generic function
-    ($f:expr) => {
-        unsafe { FuncPtr::new($f as *const ()) }
-    };
+    ($f:expr) => {{
+        let ptr = $f as *const ();
+        unsafe { FuncPtr::new(ptr) }
+    }};
 }
 
 /// Converts a closure to a `FuncPtr`.
@@ -492,12 +493,6 @@ impl FuncPtr {
         // pointer is indeed a valid function pointer.
         let p = ptr as *mut ();
         let nn = NonNull::new(p).expect("Pointer must not be null");
-
-        const MIN_FUNC_PTR_ALIGN: usize = std::mem::size_of::<usize>();
-        assert!(
-            (nn.as_ptr() as usize) % MIN_FUNC_PTR_ALIGN == 0,
-            "Pointer has insufficient alignment for function pointer"
-        );
 
         FuncPtr(nn)
     }

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -429,12 +429,12 @@ impl FuncPtr {
     /// The caller must ensure that the pointer is valid and points to a function.
     pub unsafe fn new(ptr: *const ()) -> Self {
         let p = ptr as *mut ();
-        let nn = NonNull::new(p).expect("FuncPtr::new: pointer must not be null");
+        let nn = NonNull::new(p).expect("Pointer must not be null");
 
         const MIN_FUNC_PTR_ALIGN: usize = std::mem::size_of::<usize>();
         assert!(
             (nn.as_ptr() as usize) % MIN_FUNC_PTR_ALIGN == 0,
-            "FuncPtr::new: pointer has insufficient alignment for function pointer"
+            "Pointer has insufficient alignment for function pointer"
         );
 
         FuncPtr(nn)

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -18,68 +18,11 @@ fn test_will_execute_raw_null_pointer_should_panic() {
 }
 
 #[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_raw_without_provenance_pointer_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!(foo))
-        .will_execute_raw(injectorpp::func!(std::ptr::without_provenance(0x123456789)));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_raw_misaligned_pointer_sub_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!(foo))
-        .will_execute_raw(injectorpp::func!((foo as *const ()).wrapping_byte_sub(1)));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_raw_misaligned_pointer_add_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!(foo))
-        .will_execute_raw(injectorpp::func!((foo as *const ()).wrapping_byte_add(1)));
-}
-
-#[test]
 #[should_panic(expected = "Pointer must not be null")]
 fn test_will_execute_null_pointer_should_panic() {
     let mut injector = InjectorPP::new();
     injector.when_called(injectorpp::func!(foo)).will_execute((
         unsafe { FuncPtr::new(std::ptr::null()) },
-        CallCountVerifier::Dummy,
-    ));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_without_provenance_pointer_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector.when_called(injectorpp::func!(foo)).will_execute((
-        unsafe { FuncPtr::new(std::ptr::without_provenance(0x123456789)) },
-        CallCountVerifier::Dummy,
-    ));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_misaligned_pointer_sub_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector.when_called(injectorpp::func!(foo)).will_execute((
-        unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_sub(1)) },
-        CallCountVerifier::Dummy,
-    ));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_will_execute_misaligned_pointer_add_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector.when_called(injectorpp::func!(foo)).will_execute((
-        unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_add(1)) },
         CallCountVerifier::Dummy,
     ));
 }
@@ -96,42 +39,6 @@ fn test_when_called_null_pointer_should_panic() {
         ));
 }
 
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_when_called_without_provenance_pointer_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!(std::ptr::without_provenance(0x123456789)))
-        .will_execute(injectorpp::fake!(
-            func_type: fn() -> (),
-            returns: ()
-        ));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_when_called_misaligned_pointer_sub_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!((foo as *const ()).wrapping_byte_sub(1)))
-        .will_execute(injectorpp::fake!(
-            func_type: fn() -> (),
-            returns: ()
-        ));
-}
-
-#[test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-fn test_when_called_misaligned_pointer_add_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called(injectorpp::func!((foo as *const ()).wrapping_byte_add(1)))
-        .will_execute(injectorpp::fake!(
-            func_type: fn() -> (),
-            returns: ()
-        ));
-}
-
 #[tokio::test]
 #[should_panic(expected = "Pointer must not be null")]
 async fn test_will_return_async_null_pointer_should_panic() {
@@ -141,37 +48,4 @@ async fn test_will_return_async_null_pointer_should_panic() {
             u32::default()
         )))
         .will_return_async(unsafe { FuncPtr::new(std::ptr::null()) });
-}
-
-#[tokio::test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-async fn test_will_return_async_without_provenance_pointer_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
-            u32::default()
-        )))
-        .will_return_async(unsafe { FuncPtr::new(std::ptr::without_provenance(0x123456789)) });
-}
-
-#[tokio::test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-async fn test_will_return_async_misaligned_pointer_sub_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
-            u32::default()
-        )))
-        .will_return_async(unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_sub(1)) });
-}
-
-#[tokio::test]
-#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
-async fn test_will_return_async_misaligned_pointer_add_should_panic() {
-    let mut injector = InjectorPP::new();
-    injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
-            u32::default()
-        )))
-        .will_return_async(unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_add(1)) });
 }

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -1,0 +1,177 @@
+use injectorpp::interface::injector::*;
+
+fn foo() {
+    println!("foo");
+}
+
+async fn simple_async_func_u32_add_one(x: u32) -> u32 {
+    x + 1
+}
+
+#[test]
+#[should_panic(expected = "Pointer must not be null")]
+fn test_will_execute_raw_null_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(foo))
+        .will_execute_raw(injectorpp::func!(std::ptr::null()));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_raw_without_provenance_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(foo))
+        .will_execute_raw(injectorpp::func!(std::ptr::without_provenance(0x123456789)));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_raw_misaligned_pointer_sub_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(foo))
+        .will_execute_raw(injectorpp::func!((foo as *const ()).wrapping_byte_sub(1)));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_raw_misaligned_pointer_add_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(foo))
+        .will_execute_raw(injectorpp::func!((foo as *const ()).wrapping_byte_add(1)));
+}
+
+#[test]
+#[should_panic(expected = "Pointer must not be null")]
+fn test_will_execute_null_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector.when_called(injectorpp::func!(foo)).will_execute((
+        unsafe { FuncPtr::new(std::ptr::null()) },
+        CallCountVerifier::Dummy,
+    ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_without_provenance_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector.when_called(injectorpp::func!(foo)).will_execute((
+        unsafe { FuncPtr::new(std::ptr::without_provenance(0x123456789)) },
+        CallCountVerifier::Dummy,
+    ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_misaligned_pointer_sub_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector.when_called(injectorpp::func!(foo)).will_execute((
+        unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_sub(1)) },
+        CallCountVerifier::Dummy,
+    ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_will_execute_misaligned_pointer_add_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector.when_called(injectorpp::func!(foo)).will_execute((
+        unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_add(1)) },
+        CallCountVerifier::Dummy,
+    ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer must not be null")]
+fn test_when_called_null_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(std::ptr::null()))
+        .will_execute(injectorpp::fake!(
+            func_type: fn() -> (),
+            returns: ()
+        ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_when_called_without_provenance_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(std::ptr::without_provenance(0x123456789)))
+        .will_execute(injectorpp::fake!(
+            func_type: fn() -> (),
+            returns: ()
+        ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_when_called_misaligned_pointer_sub_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!((foo as *const ()).wrapping_byte_sub(1)))
+        .will_execute(injectorpp::fake!(
+            func_type: fn() -> (),
+            returns: ()
+        ));
+}
+
+#[test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+fn test_when_called_misaligned_pointer_add_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!((foo as *const ()).wrapping_byte_add(1)))
+        .will_execute(injectorpp::fake!(
+            func_type: fn() -> (),
+            returns: ()
+        ));
+}
+
+#[tokio::test]
+#[should_panic(expected = "Pointer must not be null")]
+async fn test_will_return_async_null_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
+            u32::default()
+        )))
+        .will_return_async(unsafe { FuncPtr::new(std::ptr::null()) });
+}
+
+#[tokio::test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+async fn test_will_return_async_without_provenance_pointer_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
+            u32::default()
+        )))
+        .will_return_async(unsafe { FuncPtr::new(std::ptr::without_provenance(0x123456789)) });
+}
+
+#[tokio::test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+async fn test_will_return_async_misaligned_pointer_sub_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
+            u32::default()
+        )))
+        .will_return_async(unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_sub(1)) });
+}
+
+#[tokio::test]
+#[should_panic(expected = "Pointer has insufficient alignment for function pointer")]
+async fn test_will_return_async_misaligned_pointer_add_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
+            u32::default()
+        )))
+        .will_return_async(unsafe { FuncPtr::new((foo as *const ()).wrapping_byte_add(1)) });
+}


### PR DESCRIPTION
This PR introduces a `FuncPtr` type to abstract unsafe input away from the public API.

`FuncPtr` is used to convert functions and closures to function pointers, ensuring that the function signature matches the expected signature for injectorpp.

`FuncPtr::new` is unsafe and requires the function pointer to remain valid for the entire duration it's used by injectorpp. This ensures the responsibility of maintaining the function pointer's validity lies with the caller.

`FuncPtr::new` also do basic check as the best effort. However, caller still needs to ensure the pointer is a valid function through the injectorpp lifetime.

Fix #45 