### PR TITLE
MacOS Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
             target: aarch64-pc-windows-msvc
           - os: macos-latest
             target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
     name: Build & test on ${{ matrix.os }} / ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
           - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
             target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
 
     runs-on: ${{ matrix.os }}
     name: Build & test on ${{ matrix.os }} / ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ description = "Injectorpp is a powerful tool designed to facilitate the writing 
 [dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.4"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], default-features = false }
 azure_core = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "Injectorpp is a powerful tool designed to facilitate the writing 
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach2 = "0.4"
+mach2 = "0.5"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], default-features = false }

--- a/src/injector_core.rs
+++ b/src/injector_core.rs
@@ -2,6 +2,7 @@ pub(crate) mod arm64_codegenerator;
 pub(crate) mod common;
 pub(crate) mod internal;
 pub(crate) mod linuxapi;
+pub(crate) mod macosapi;
 pub(crate) mod patch_amd64;
 pub(crate) mod patch_arm;
 pub(crate) mod patch_arm64;

--- a/src/injector_core/arm64_codegenerator.rs
+++ b/src/injector_core/arm64_codegenerator.rs
@@ -339,3 +339,50 @@ pub(crate) fn emit_movz(
 
     code_bits
 }
+
+/// Emit machine code for a long jump if the target falls out of range of the +-128MB bounds imposed
+/// by ARM's branch instruction. If it is, we use the x16 register to store the address and jump
+/// there as such:
+///
+/// ADRP x16, target
+/// ADD x16, x16, #:lo12:
+/// BR x16
+pub(crate) fn maybe_emit_long_jump(pc: usize, target: usize) -> Vec<u32> {
+    // We are storing the address in x16.
+    const REGISTER: u32 = 16;
+
+    let mut words = Vec::with_capacity(3);
+
+    // Simple B case where we are in bounds.
+    let disp = (target as i128).wrapping_sub(pc as i128);
+    if disp >= -(1i128 << 27) && disp < (1i128 << 27) {
+        let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
+        let b_inst = 0b000101 << 26 | imm26;
+        words.push(b_inst);
+        return words;
+    }
+
+    let page_pc = pc & !0xfff;
+    let page_target = target & !0xfff;
+    let page_diff = ((page_target as i64).wrapping_sub(page_pc as i64)) >> 12;
+
+    // Split up the page difference into a 21 bit signed immediate.
+    let imm21 = (page_diff as u64) & 0x1f_ffff;
+    let immlo = ((imm21 >> 0) & 0b11) as u32;
+    let immhi = ((imm21 >> 2) & 0x7ffff) as u32;
+
+    // ADRP instruction.
+    let adrp = 0x9000_0000 | (immlo << 29) | (immhi << 5) | REGISTER;
+    words.push(adrp);
+
+    // ADD instruction with the low 12 bits.
+    let low12 = (target & 0xfff) as u32;
+    let add = 0x9100_0000 | (low12 << 10) | (REGISTER << 5) | REGISTER;
+    words.push(add);
+
+    // BR instruction to register 16.
+    let br = 0xd61f_0000 | (REGISTER << 5);
+    words.push(br);
+
+    words
+}

--- a/src/injector_core/arm64_codegenerator.rs
+++ b/src/injector_core/arm64_codegenerator.rs
@@ -347,6 +347,7 @@ pub(crate) fn emit_movz(
 /// ADRP x16, target
 /// ADD x16, x16, #:lo12:
 /// BR x16
+#[cfg(target_os = "macos")]
 pub(crate) fn maybe_emit_long_jump(pc: usize, target: usize) -> Vec<u32> {
     // We are storing the address in x16.
     const REGISTER: u32 = 16;

--- a/src/injector_core/arm64_codegenerator.rs
+++ b/src/injector_core/arm64_codegenerator.rs
@@ -355,7 +355,7 @@ pub(crate) fn maybe_emit_long_jump(pc: usize, target: usize) -> Vec<u32> {
 
     // Simple B case where we are in bounds.
     let disp = (target as i128).wrapping_sub(pc as i128);
-    if disp >= -(1i128 << 27) && disp < (1i128 << 27) {
+    if (-(1i128 << 27)..(1i128 << 27)).contains(&disp) {
         let imm26 = ((disp >> 2) as u32) & 0x03ff_ffff;
         let b_inst = 0b000101 << 26 | imm26;
         words.push(b_inst);
@@ -368,7 +368,7 @@ pub(crate) fn maybe_emit_long_jump(pc: usize, target: usize) -> Vec<u32> {
 
     // Split up the page difference into a 21 bit signed immediate.
     let imm21 = (page_diff as u64) & 0x1f_ffff;
-    let immlo = ((imm21 >> 0) & 0b11) as u32;
+    let immlo = (imm21 & 0b11) as u32;
     let immhi = ((imm21 >> 2) & 0x7ffff) as u32;
 
     // ADRP instruction.

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -60,7 +60,7 @@ pub(crate) fn allocate_jit_memory(src: &FuncPtrInternal, code_size: usize) -> *m
 /// Allocate JIT memory on Unix platforms.
 ///
 /// On MacOS, both aarch64 and x86_64 architectures have a ±2GB memory range.
-/// On MacOS, both aarch64 and x86_64 architectures have a ±128MB memory range.
+/// On Linux, both aarch64 and x86_64 architectures have a ±128MB memory range.
 /// Other architectures have no enforced address range constraint.
 ///
 /// # Panics

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -68,6 +68,12 @@ pub(crate) fn allocate_jit_memory(src: &FuncPtrInternal, code_size: usize) -> *m
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 fn allocate_jit_memory_unix(_src: &FuncPtrInternal, code_size: usize) -> *mut u8 {
+    #[cfg(target_os = "macos")]
+    let flags = libc::MAP_ANON | libc::MAP_PRIVATE | libc::MAP_JIT;
+
+    #[cfg(target_os = "linux")]
+    let flags = libc::MAP_ANONYMOUS | libc::MAP_PRIVATE;
+
     #[cfg(target_arch = "aarch64")]
     {
         let original_addr = _src.as_ptr() as u64;
@@ -81,7 +87,7 @@ fn allocate_jit_memory_unix(_src: &FuncPtrInternal, code_size: usize) -> *mut u8
                     start_address as *mut c_void,
                     code_size,
                     PROT_READ | PROT_WRITE | PROT_EXEC,
-                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                    flags,
                     -1,
                     0,
                 )
@@ -114,7 +120,7 @@ fn allocate_jit_memory_unix(_src: &FuncPtrInternal, code_size: usize) -> *mut u8
                     start_address as *mut c_void,
                     code_size,
                     PROT_READ | PROT_WRITE | PROT_EXEC,
-                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                    flags,
                     -1,
                     0,
                 )

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -313,10 +313,7 @@ pub(crate) unsafe fn patch_function(func: *mut u8, patch: &[u8]) {
     use mach2::vm::{mach_vm_protect, mach_vm_remap};
     use mach2::vm_inherit::VM_INHERIT_NONE;
     use mach2::vm_prot::VM_PROT_COPY;
-    use mach2::vm_statistics::{VM_FLAGS_ANYWHERE, VM_FLAGS_OVERWRITE};
-
-    // TODO: Why is this not defined in mach2?
-    const VM_FLAGS_RETURN_DATA_ADDR: i32 = 0x100000;
+    use mach2::vm_statistics::{VM_FLAGS_ANYWHERE, VM_FLAGS_OVERWRITE, VM_FLAGS_RETURN_DATA_ADDR};
 
     let mut addr = func as mach_vm_address_t;
     let mut remap: mach_vm_address_t = std::mem::zeroed();

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -343,7 +343,6 @@ unsafe fn make_memory_writable_and_executable_linux(func: *mut u8) {
     let page_size = sysconf(_SC_PAGESIZE) as usize;
     let addr = func as usize;
     let page_start = addr & !(page_size - 1);
-
     if libc::mprotect(
         page_start as *mut c_void,
         page_size,

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -59,7 +59,8 @@ pub(crate) fn allocate_jit_memory(src: &FuncPtrInternal, code_size: usize) -> *m
 // See https://github.com/microsoft/injectorppforrust/issues/88
 /// Allocate JIT memory on Unix platforms.
 ///
-/// Both aarch64 and x86_64 architectures have a ±2GB memory range.
+/// On MacOS, both aarch64 and x86_64 architectures have a ±2GB memory range.
+/// On MacOS, both aarch64 and x86_64 architectures have a ±128MB memory range.
 /// Other architectures have no enforced address range constraint.
 ///
 /// # Panics
@@ -110,7 +111,7 @@ fn allocate_jit_memory_unix(_src: &FuncPtrInternal, code_size: usize) -> *mut u8
         }
 
         panic!(
-            "Failed to allocate JIT memory within ±2GB of source on {} arch",
+            "Failed to allocate JIT memory within ±{max_range} of source on {} arch",
             std::env::consts::ARCH
         );
     }

--- a/src/injector_core/macosapi.rs
+++ b/src/injector_core/macosapi.rs
@@ -1,7 +1,6 @@
 #![cfg(target_os = "macos")]
 
 extern "C" {
-    /// Prepares memory for execution, typically by invalidating the instruction cache for the
-    /// indicated range.
+    pub(crate) fn sys_dcache_flush(start: *mut u8, len: usize);
     pub(crate) fn sys_icache_invalidate(start: *mut u8, len: usize);
 }

--- a/src/injector_core/macosapi.rs
+++ b/src/injector_core/macosapi.rs
@@ -1,0 +1,7 @@
+#![cfg(target_os = "macos")]
+
+extern "C" {
+    /// Prepares memory for execution, typically by invalidating the instruction cache for the
+    /// indicated range.
+    pub(crate) fn sys_icache_invalidate(start: *mut u8, len: usize);
+}

--- a/src/injector_core/patch_arm64.rs
+++ b/src/injector_core/patch_arm64.rs
@@ -123,17 +123,36 @@ fn apply_branch_patch(
 
     let func_addr = src.as_ptr() as usize;
     let jit_addr = jit_memory as usize;
-    let instrs = maybe_emit_long_jump(func_addr, jit_addr);
 
     let mut patch = [0u8; PATCH_SIZE];
-    if instrs.len() == 1 {
-        patch[0..4].copy_from_slice(&instrs[0].to_le_bytes());
+
+    #[cfg(target_os = "macos")]
+    {
+        let instrs = maybe_emit_long_jump(func_addr, jit_addr);
+        if instrs.len() == 1 {
+            patch[0..4].copy_from_slice(&instrs[0].to_le_bytes());
+            patch[4..8].copy_from_slice(&NOP.to_le_bytes());
+            patch[8..12].copy_from_slice(&NOP.to_le_bytes());
+        } else {
+            patch[0..4].copy_from_slice(&instrs[0].to_le_bytes());
+            patch[4..8].copy_from_slice(&instrs[1].to_le_bytes());
+            patch[8..12].copy_from_slice(&instrs[2].to_le_bytes());
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        const BRANCH_RANGE: std::ops::RangeInclusive<isize> = -0x2000000..=0x1FFF_FFFF; // ±32MB
+
+        let offset = (jit_addr as isize - func_addr as isize) / 4;
+        if !BRANCH_RANGE.contains(&offset) {
+            panic!("JIT memory is out of branch range: offset = {offset}, expected ±32MB");
+        }
+
+        let branch_instr: u32 = 0x14000000 | ((offset as u32) & 0x03FF_FFFF);
+        patch[0..4].copy_from_slice(&branch_instr.to_le_bytes());
         patch[4..8].copy_from_slice(&NOP.to_le_bytes());
         patch[8..12].copy_from_slice(&NOP.to_le_bytes());
-    } else {
-        patch[0..4].copy_from_slice(&instrs[0].to_le_bytes());
-        patch[4..8].copy_from_slice(&instrs[1].to_le_bytes());
-        patch[8..12].copy_from_slice(&instrs[2].to_le_bytes());
     }
 
     unsafe {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -5,7 +5,7 @@ use std::io::BufReader;
 use std::io::Result;
 use std::io::Write;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::fd::FromRawFd;
 
 #[cfg(target_os = "windows")]
@@ -25,7 +25,7 @@ extern "system" {
 
 unsafe fn create_fake_file_object() -> File {
     // Create a fake file object using a raw file descriptor
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     unsafe {
         // Create a pipe, use the read end, and immediately close the write end
         let mut fds = [0; 2];


### PR DESCRIPTION
This is a work in progress for #43.

I tried to add MacOS support via this patch but have been dealing with what I believe to be hardened runtime restrictions. I'm developing on an M2 chip. I get `SIGBUS` errors when the library tries to copy the generated ASM into the memory-mapped region. I am posting this in hopes that someone with more experience can comment on whether or not I am on the right path at least. Below are some links to documentation I read through.

- [Apple Silicon JIT](https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon)
- [JIT Execution Entitlement](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.allow-jit)
- [MacOS Cache Clear](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sys_icache_invalidate.3.html)