### PR TITLE
Use native Linux arm64 image in CI instead of QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - os: windows-latest
@@ -49,9 +51,17 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cargo build --target ${{ matrix.target }} --release
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" && "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            echo "skip"
+          else
+            cargo build --target ${{ matrix.target }} --release
+          fi
 
       - name: Test
         shell: bash
         run: |
-          cargo test --target ${{ matrix.target }} -- --nocapture
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" && "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            echo "skip"
+          else
+            cargo test --target ${{ matrix.target }} -- --nocapture
+          fi


### PR DESCRIPTION
Use native Linux arm64 image in CI.

Fix #44