### PR TITLE
Add type check async api

### DIFF
--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -153,7 +153,7 @@ impl InjectorPP {
     /// ```
     pub fn when_called_async<F, T>(
         &mut self,
-        _: (Pin<&mut F>, String),
+        _: (Pin<&mut F>, &'static str),
     ) -> WhenCalledBuilderAsync<'_>
     where
         F: Future<Output = T>,

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -1,6 +1,7 @@
 use crate::injector_core::common::*;
 use crate::injector_core::internal::*;
 pub use crate::interface::func_ptr::FuncPtr;
+pub use crate::interface::macros::__assert_future_output;
 pub use crate::interface::verifier::CallCountVerifier;
 
 use std::future::Future;

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -151,10 +151,14 @@ impl InjectorPP {
     ///     assert_eq!(result, 123); // The patched value
     /// }
     /// ```
-    pub fn when_called_async<F, T>(&mut self, _: Pin<&mut F>) -> WhenCalledBuilderAsync<'_>
+    pub fn when_called_async<F, T>(
+        &mut self,
+        _: (Pin<&mut F>, String),
+    ) -> WhenCalledBuilderAsync<'_>
     where
         F: Future<Output = T>,
     {
+        // let t = std::any::type_name::<bool>();
         let poll_fn: fn(Pin<&mut F>, &mut Context<'_>) -> Poll<T> = <F as Future>::poll;
         let when = WhenCalled::new(
             crate::func!(poll_fn, fn(Pin<&mut F>, &mut Context<'_>) -> Poll<T>).func_ptr_internal,

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -144,7 +144,7 @@ impl InjectorPP {
     /// async fn main() {
     ///     let mut injector = InjectorPP::new();
     ///     injector
-    ///         .when_called_async(injectorpp::async_func!(async_add_one(u32::default())))
+    ///         .when_called_async(injectorpp::async_func!(async_add_one(u32::default()), u32))
     ///         .will_return_async(injectorpp::async_return!(123, u32));
     ///
     ///     let result = async_add_one(5).await;
@@ -164,7 +164,11 @@ impl InjectorPP {
         );
 
         let signature = fake_pair.1;
-        WhenCalledBuilderAsync { lib: self, when, expected_signature: signature }
+        WhenCalledBuilderAsync {
+            lib: self,
+            when,
+            expected_signature: signature,
+        }
     }
 }
 
@@ -393,7 +397,7 @@ impl WhenCalledBuilderAsync<'_> {
     /// async fn main() {
     ///     let mut injector = InjectorPP::new();
     ///     injector
-    ///         .when_called_async(injectorpp::async_func!(async_func_bool(true)))
+    ///         .when_called_async(injectorpp::async_func!(async_func_bool(true), bool))
     ///         .will_return_async(injectorpp::async_return!(false, bool));
     ///
     ///     let result = async_func_bool(true).await;

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -91,12 +91,23 @@ macro_rules! closure {
     }};
 }
 
+#[doc(hidden)]
+pub fn __assert_future_output<Fut, T>(_: &mut Fut)
+where
+    Fut: std::future::Future<Output = T>,
+{
+}
+
 // Ensure the async function can be correctly used in injectorpp.
 #[macro_export]
 macro_rules! async_func {
     ($expr:expr, $ty:ty) => {{
+        let mut __fut = $expr;
+
+        let _ = __assert_future_output::<_, $ty>(&mut __fut);
+
         let sig = std::any::type_name::<fn() -> std::task::Poll<$ty>>();
-        (std::pin::pin!($expr), sig)
+        (std::pin::pin!(__fut), sig)
     }};
 }
 

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -95,7 +95,7 @@ macro_rules! closure {
 #[macro_export]
 macro_rules! async_func {
     ($expr:expr, $ty:ty) => {{
-        let sig = std::any::type_name::<std::task::Poll<$ty>>();
+        let sig = std::any::type_name::<fn() -> std::task::Poll<$ty>>();
         (std::pin::pin!($expr), sig)
     }};
 }

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -111,6 +111,17 @@ macro_rules! async_func {
     }};
 }
 
+#[macro_export]
+macro_rules! async_return {
+    ($val:expr, $ty:ty) => {{
+        fn generated_poll_fn() -> std::task::Poll<$ty> {
+            std::task::Poll::Ready($val)
+        }
+
+        $crate::func!(generated_poll_fn, fn() -> std::task::Poll<$ty>)
+    }};
+}
+
 /// Creates a mock function implementation with configurable behavior and verification.
 ///
 /// This macro generates a function that can be used to replace real functions during testing.
@@ -493,16 +504,5 @@ macro_rules! fake {
          let f: fn($($arg_ty),*) -> () = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
-    }};
-}
-
-#[macro_export]
-macro_rules! async_return {
-    ($val:expr, $ty:ty) => {{
-        fn generated_poll_fn() -> std::task::Poll<$ty> {
-            std::task::Poll::Ready($val)
-        }
-
-        $crate::func!(generated_poll_fn, fn() -> std::task::Poll<$ty>)
     }};
 }

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -96,7 +96,7 @@ macro_rules! closure {
 macro_rules! async_func {
     ($expr:expr, $ty:ty) => {{
         let sig = std::any::type_name::<std::task::Poll<$ty>>();
-        (std::pin::pin!($expr), sig.to_string())
+        (std::pin::pin!($expr), sig)
     }};
 }
 

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -94,9 +94,10 @@ macro_rules! closure {
 // Ensure the async function can be correctly used in injectorpp.
 #[macro_export]
 macro_rules! async_func {
-    ($expr:expr) => {
-        std::pin::pin!($expr)
-    };
+    ($expr:expr, $ty:ty) => {{
+        let sig = std::any::type_name::<std::task::Poll<$ty>>();
+        (std::pin::pin!($expr), sig.to_string())
+    }};
 }
 
 /// Creates a mock function implementation with configurable behavior and verification.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@
 //!     injector
 //!         .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
 //!             u32::default()
-//!         )))
+//!         ), u32))
 //!         .will_return_async(injectorpp::async_return!(123, u32));
 //!
 //!     let x = simple_async_func_u32_add_one(1).await;
@@ -352,7 +352,7 @@
 //!     injector
 //!         .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_two(
 //!             u32::default()
-//!         )))
+//!         ), u32))
 //!         .will_return_async(injectorpp::async_return!(678, u32));
 //!
 //!     // Now because it's faked the return value should be changed
@@ -368,7 +368,7 @@
 //!     injector
 //!         .when_called_async(injectorpp::async_func!(simple_async_func_bool(
 //!             bool::default()
-//!         )))
+//!         ), bool))
 //!         .will_return_async(injectorpp::async_return!(false, bool));
 //!
 //!     // Now because it's faked the return value should be false
@@ -406,7 +406,7 @@
 //!
 //!         let mut injector = InjectorPP::new();
 //!         injector
-//!             .when_called_async(injectorpp::async_func!(temp_client.get()))
+//!             .when_called_async(injectorpp::async_func!(temp_client.get(), String))
 //!             .will_return_async(injectorpp::async_return!(
 //!                 "Fake GET response".to_string(),
 //!                 String

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -31,9 +31,10 @@ async fn test_simple_async_func_should_success() {
     let mut injector = InjectorPP::new();
 
     injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
-            u32::default()
-        )))
+        .when_called_async(injectorpp::async_func!(
+            simple_async_func_u32_add_one(u32::default()),
+            u32
+        ))
         .will_return_async(injectorpp::async_return!(123, u32));
 
     let x = simple_async_func_u32_add_one(1).await;
@@ -44,9 +45,10 @@ async fn test_simple_async_func_should_success() {
     assert_eq!(x, 3);
 
     injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_two(
-            u32::default()
-        )))
+        .when_called_async(injectorpp::async_func!(
+            simple_async_func_u32_add_two(u32::default()),
+            u32
+        ))
         .will_return_async(injectorpp::async_return!(678, u32));
 
     // Now because it's faked the return value should be changed
@@ -58,9 +60,10 @@ async fn test_simple_async_func_should_success() {
     assert_eq!(y, true);
 
     injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_bool(
-            bool::default()
-        )))
+        .when_called_async(injectorpp::async_func!(
+            simple_async_func_bool(bool::default()),
+            bool
+        ))
         .will_return_async(injectorpp::async_return!(false, bool));
 
     // Now because it's faked the return value should be false
@@ -79,7 +82,7 @@ async fn test_complex_struct_async_func_without_param_should_success() {
 
         let mut injector = InjectorPP::new();
         injector
-            .when_called_async(injectorpp::async_func!(temp_client.get()))
+            .when_called_async(injectorpp::async_func!(temp_client.get(), String))
             .will_return_async(injectorpp::async_return!(
                 "Fake GET response".to_string(),
                 String
@@ -114,7 +117,10 @@ async fn test_complex_struct_async_func_with_param_should_success() {
 
         let mut injector = InjectorPP::new();
         injector
-            .when_called_async(injectorpp::async_func!(temp_client.post("test payload")))
+            .when_called_async(injectorpp::async_func!(
+                temp_client.post("test payload"),
+                String
+            ))
             .will_return_async(injectorpp::async_return!(
                 "Fake POST response".to_string(),
                 String

--- a/tests/azure.rs
+++ b/tests/azure.rs
@@ -16,7 +16,8 @@ async fn test_azure_http_client_always_return_200() {
     let mut injector = InjectorPP::new();
     injector
         .when_called_async(injectorpp::async_func!(
-            temp_client.execute_request(&mut temp_req)
+            temp_client.execute_request(&mut temp_req),
+            std::result::Result<RawResponse, Error>
         ))
         .will_return_async(injectorpp::async_return!(
             // always return an Ok(RawResponse) with status 200

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -89,3 +89,15 @@ async fn test_will_return_async_null_pointer_should_panic() {
         ))
         .will_return_async(unsafe { FuncPtr::new(std::ptr::null(), std::any::type_name::<u32>()) });
 }
+
+#[tokio::test]
+#[should_panic(expected = "Signature mismatch")]
+async fn test_will_return_async_mismatched_type_should_panic() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called_async(injectorpp::async_func!(
+            simple_async_func_u32_add_one(u32::default()),
+            u32
+        ))
+        .will_return_async(injectorpp::async_return!("Test Value".to_string(), String));
+}

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -83,13 +83,9 @@ fn test_will_execute_null_pointer_should_panic() {
 async fn test_will_return_async_null_pointer_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called_async(injectorpp::async_func!(simple_async_func_u32_add_one(
-            u32::default()
-        )))
-        .will_return_async(unsafe {
-            FuncPtr::new(
-                std::ptr::null(),
-                std::any::type_name_of_val(&simple_async_func_u32_add_one),
-            )
-        });
+        .when_called_async(injectorpp::async_func!(
+            simple_async_func_u32_add_one(u32::default()),
+            u32
+        ))
+        .will_return_async(unsafe { FuncPtr::new(std::ptr::null(), std::any::type_name::<u32>()) });
 }


### PR DESCRIPTION
This is a breaking change. It requires `async_func!` providing returning type. The PR adds type check for async API to ensure the type provided in `async_func!` must match the type provided in `will_return_async`.