### PR TITLE
Add simplified func syntax

### DIFF
--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -106,8 +106,8 @@ impl InjectorPP {
     ///
     /// let mut injector = InjectorPP::new();
     /// injector
-    ///     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
-    ///     .will_execute_raw(injectorpp::func!(fake_exists, fn(&Path) -> bool));
+    ///     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
+    ///     .will_execute_raw(injectorpp::func!(fn (fake_exists)(&Path) -> bool));
     ///
     /// assert!(Path::new("/non/existent/path").exists());
     /// ```
@@ -311,7 +311,7 @@ impl WhenCalledBuilder<'_> {
     ///
     /// let mut injector = InjectorPP::new();
     /// injector
-    ///     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+    ///     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
     ///     .will_execute_raw(injectorpp::closure!(fake_closure, fn(&Path) -> bool));
     ///
     /// assert!(Path::new("/nonexistent").exists());
@@ -328,8 +328,8 @@ impl WhenCalledBuilder<'_> {
     ///
     /// let mut injector = InjectorPP::new();
     /// injector
-    ///     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
-    ///     .will_execute_raw(injectorpp::func!(fake_exists, fn(&Path) -> bool));
+    ///     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
+    ///     .will_execute_raw(injectorpp::func!(fn (fake_exists)(&Path) -> bool));
     ///
     /// assert!(Path::new("/nonexistent").exists());
     /// ```
@@ -419,7 +419,7 @@ impl WhenCalledBuilder<'_> {
     ///
     /// let mut injector = InjectorPP::new();
     /// injector
-    ///     .when_called(injectorpp::func!(original_func, fn(&mut i32) -> bool))
+    ///     .when_called(injectorpp::func!(fn (original_func)(&mut i32) -> bool))
     ///     .will_execute(injectorpp::fake!(
     ///         func_type: fn(a: &mut i32) -> bool,
     ///         assign: { *a = 6 },
@@ -458,7 +458,7 @@ impl WhenCalledBuilder<'_> {
     ///
     /// let mut injector = InjectorPP::new();
     /// injector
-    ///     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+    ///     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
     ///     .will_return_boolean(true);
     ///
     /// assert!(Path::new("/nonexistent").exists());

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -27,6 +27,10 @@ macro_rules! func {
     (fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
         $crate::func!($f, fn($($arg_ty),*) -> $ret)
     }};
+
+    (fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
+        $crate::func!($f, fn($($arg_ty),*))
+    }};
 }
 
 /// Converts a function to a `FuncPtr`.

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -31,6 +31,25 @@ macro_rules! func {
     (fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
         $crate::func!($f, fn($($arg_ty),*))
     }};
+
+    (unsafe{} fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
+        $crate::func!($f, unsafe fn($($arg_ty),*) -> $ret)
+    }};
+
+    // simplified unsafe fn, unit return
+    (unsafe{} fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
+        $crate::func!($f, unsafe fn($($arg_ty),*) -> ())
+    }};
+
+    // simplified unsafe extern "C" fn with return
+    (unsafe{} extern "C" fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
+        $crate::func!($f, unsafe extern "C" fn($($arg_ty),*) -> $ret)
+    }};
+
+    // simplified unsafe extern "C" fn, unit return
+    (unsafe{} extern "C" fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
+        $crate::func!($f, unsafe extern "C" fn($($arg_ty),*) -> ())
+    }};
 }
 
 /// Converts a function to a `FuncPtr`.

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -23,30 +23,32 @@ macro_rules! func {
         unsafe { FuncPtr::new(ptr, sig) }
     }};
 
-    // Simplified syntax: allow using `func!(fn (Path::exists)(&Path) -> bool)`
+    // Simplified fn with return
     (fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
         $crate::func!($f, fn($($arg_ty),*) -> $ret)
     }};
 
+    // Simplified fn with unit return
     (fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
         $crate::func!($f, fn($($arg_ty),*))
     }};
 
+    // Simplified unsafe fn with return
     (unsafe{} fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
         $crate::func!($f, unsafe fn($($arg_ty),*) -> $ret)
     }};
 
-    // simplified unsafe fn, unit return
+    // Simplified unsafe fn with unit return
     (unsafe{} fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
         $crate::func!($f, unsafe fn($($arg_ty),*) -> ())
     }};
 
-    // simplified unsafe extern "C" fn with return
+    // Simplified unsafe extern "C" fn with return
     (unsafe{} extern "C" fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
         $crate::func!($f, unsafe extern "C" fn($($arg_ty),*) -> $ret)
     }};
 
-    // simplified unsafe extern "C" fn, unit return
+    // Simplified unsafe extern "C" fn with unit return
     (unsafe{} extern "C" fn ( $f:expr ) ( $($arg_ty:ty),* )) => {{
         $crate::func!($f, unsafe extern "C" fn($($arg_ty),*) -> ())
     }};

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -22,6 +22,11 @@ macro_rules! func {
 
         unsafe { FuncPtr::new(ptr, sig) }
     }};
+
+    // Simplified syntax: allow using `func!(fn (Path::exists)(&Path) -> bool)`
+    (fn ( $f:expr ) ( $($arg_ty:ty),* ) -> $ret:ty) => {{
+        $crate::func!($f, fn($($arg_ty),*) -> $ret)
+    }};
 }
 
 /// Converts a function to a `FuncPtr`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(fs::create_dir_all, fn(&'static str) -> std::io::Result<()>))
+//!     .when_called(injectorpp::func!(fn (fs::create_dir_all)(&'static str) -> std::io::Result<()>))
 //!     .will_execute(injectorpp::fake!(
 //!         func_type: fn(path: &str) -> std::io::Result<()>,
 //!         when: path == "/tmp/target_files",
@@ -95,7 +95,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+//!     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
 //!     .will_return_boolean(true);
 //!
 //! assert!(Path::new("/not/exist").exists());
@@ -125,7 +125,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+//!     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
 //!     .will_execute(injectorpp::fake!(
 //!         func_type: fn(_path: &Path) -> bool,
 //!         returns: true
@@ -150,8 +150,7 @@
 //! let mut injector = InjectorPP::new();
 //! injector
 //!     .when_called(injectorpp::func!(
-//!         complex_generic_multiple_types_func,
-//!         fn(&'static str, bool, i32) -> String
+//!         fn (complex_generic_multiple_types_func)(&'static str, bool, i32) -> String
 //!     ))
 //!     .will_execute(injectorpp::fake!(
 //!         func_type: fn(a: &str, b: bool, c: i32) -> String,
@@ -179,7 +178,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(multiple_reference_params_func, fn(&mut i32, &mut bool) -> bool))
+//!     .when_called(injectorpp::func!(fn (multiple_reference_params_func)(&mut i32, &mut bool) -> bool))
 //!     .will_execute(injectorpp::fake!(
 //!         func_type: fn(a: &mut i32, b: &mut bool) -> bool,
 //!         assign: { *a = 6; *b = true },
@@ -216,7 +215,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(Foo::add, fn(&Foo, i32) -> i32))
+//!     .when_called(injectorpp::func!(fn (Foo::add)(&Foo, i32) -> i32))
 //!     .will_execute(injectorpp::fake!(
 //!         func_type: fn(f: &Foo, value: i32) -> i32,
 //!         when: f.value > 0,
@@ -243,8 +242,7 @@
 //!     let mut injector = InjectorPP::new();
 //!     injector
 //!         .when_called(injectorpp::func!(
-//!             complex_generic_single_type_always_fail_func,
-//!             fn(&'static str) -> std::io::Result<()>
+//!             fn (complex_generic_single_type_always_fail_func)(&'static str) -> std::io::Result<()>
 //!         ))
 //!         .will_execute(injectorpp::fake!(
 //!             func_type: fn(path: &str) -> std::io::Result<()>,
@@ -278,8 +276,8 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
-//!     .will_execute_raw(injectorpp::func!(fake_path_exists, fn(&Path) -> bool));
+//!     .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
+//!     .will_execute_raw(injectorpp::func!(fn (fake_path_exists)(&Path) -> bool));
 //!
 //! let test_path = "/path/that/does/not/exist";
 //! let result = Path::new(test_path).exists();
@@ -302,7 +300,7 @@
 //!
 //! let mut injector = InjectorPP::new();
 //! injector
-//!     .when_called(injectorpp::func!(func_no_return, fn()))
+//!     .when_called(injectorpp::func!(fn (func_no_return)()))
 //!     .will_execute_raw(injectorpp::closure!(fake_closure, fn()));
 //!
 //! func_no_return();

--- a/tests/cruntime.rs
+++ b/tests/cruntime.rs
@@ -13,8 +13,7 @@ fn test_fake_getenv_returns_custom_pointer() {
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            getenv,
-            unsafe extern "C" fn(*const c_char) -> *mut c_char
+            unsafe{} extern "C" fn (getenv)(*const c_char) -> *mut c_char
         ))
         .will_execute(injectorpp::fake!(
             func_type: unsafe extern "C" fn(_name: *const c_char) -> *mut c_char,
@@ -32,8 +31,7 @@ fn test_fake_getenv_when_key_matches() {
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            getenv,
-            unsafe extern "C" fn(*const c_char) -> *mut c_char
+            unsafe{} extern "C" fn(getenv)(*const c_char) -> *mut c_char
         ))
         .will_execute(injectorpp::fake!(
             func_type: unsafe extern "C" fn(name: *const c_char) -> *mut c_char,
@@ -52,8 +50,7 @@ fn test_fake_memset_assign() {
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            memset,
-            unsafe extern "C" fn(*mut c_void, c_int, usize) -> *mut c_void
+            unsafe{} extern "C" fn(memset)(*mut c_void, c_int, usize) -> *mut c_void
         ))
         .will_execute(injectorpp::fake!(
             func_type: unsafe extern "C" fn(s: *mut c_void, _c: c_int, _n: usize) -> *mut c_void,

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -28,7 +28,7 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
 fn test_will_return_boolean_mismatched_type_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(return_string, fn() -> String))
+        .when_called(injectorpp::func!(fn (return_string)() -> String))
         .will_return_boolean(true);
 }
 
@@ -37,7 +37,7 @@ fn test_will_return_boolean_mismatched_type_should_panic() {
 fn test_will_execute_when_function_signature_mismatch_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+        .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
         .will_execute(injectorpp::fake!(
             func_type: fn(_path: &str) -> bool,
             returns: true
@@ -50,8 +50,7 @@ fn test_will_execute_when_generic_function_multiple_types_signature_mismatch_sho
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func,
-            fn(&'static str, bool, i32) -> String
+            fn (complex_generic_multiple_types_func)(&'static str, bool, i32) -> String
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &str, b: bool) -> String,
@@ -66,7 +65,7 @@ fn test_will_execute_when_generic_function_multiple_types_signature_mismatch_sho
 fn test_will_execute_null_pointer_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(foo, fn()))
+        .when_called(injectorpp::func!(fn (foo)()))
         .will_execute((
             unsafe {
                 FuncPtr::new(std::ptr::null(), {

--- a/tests/will_execute.rs
+++ b/tests/will_execute.rs
@@ -86,7 +86,7 @@ impl Foo {
 fn test_will_execute_when_fake_file_dependency_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
+        .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
         .will_execute(injectorpp::fake!(
             func_type: fn(_path: &Path) -> bool,
             returns: true
@@ -443,7 +443,7 @@ fn test_will_execute_when_fake_method_can_recover() {
 fn test_will_execute_fake_unsafe_non_unit_returns_only_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_non_unit, unsafe fn(i32) -> i32))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_non_unit)(i32) -> i32))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(val: i32) -> i32,
             returns: val + 1

--- a/tests/will_execute.rs
+++ b/tests/will_execute.rs
@@ -102,10 +102,9 @@ fn test_will_execute_when_fake_file_dependency_should_success() {
 fn test_will_execute_when_fake_std_fs_read_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(
-            std::fs::read,
-            fn(&'static str) -> std::io::Result<Vec<u8>>
-        ))
+        .when_called(
+            injectorpp::func!(fn (std::fs::read)(&'static str) -> std::io::Result<Vec<u8>>),
+        )
         .will_execute(injectorpp::fake!(
             func_type: fn(_path: &str) -> std::io::Result<Vec<u8>>,
             returns: Ok(vec![1, 2, 3])
@@ -119,7 +118,7 @@ fn test_will_execute_when_fake_std_fs_read_should_success() {
 fn test_will_execute_when_fake_no_return_function_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(func_no_return, fn()))
+        .when_called(injectorpp::func!(fn (func_no_return)()))
         .will_execute(injectorpp::fake!(
             func_type: fn() -> (),
             times: 1
@@ -139,7 +138,7 @@ fn test_will_execute_when_fake_no_return_function_should_success() {
 fn test_will_execute_when_fake_no_return_function_over_called_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(func_no_return, fn()))
+        .when_called(injectorpp::func!(fn (func_no_return)()))
         .will_execute(injectorpp::fake!(
             func_type: fn() -> (),
             times: 2
@@ -171,7 +170,7 @@ fn test_will_execute_when_fake_no_return_function_over_called_should_panic() {
 fn test_will_execute_when_fake_no_return_function_under_called_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(func_no_return, fn()))
+        .when_called(injectorpp::func!(fn (func_no_return)()))
         .will_execute(injectorpp::fake!(
             func_type: fn() -> (),
             times: 3
@@ -186,8 +185,7 @@ fn test_will_execute_when_fake_generic_function_single_type_should_success() {
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_single_type_always_fail_func,
-            fn(&'static str) -> std::io::Result<()>
+            fn (complex_generic_single_type_always_fail_func)(&'static str) -> std::io::Result<()>
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(path: &str) -> std::io::Result<()>,
@@ -207,8 +205,7 @@ fn test_will_execute_when_fake_generic_function_single_type_can_recover() {
         let mut injector = InjectorPP::new();
         injector
             .when_called(injectorpp::func!(
-                complex_generic_single_type_always_fail_func,
-                fn(&'static str) -> std::io::Result<()>
+                fn (complex_generic_single_type_always_fail_func)(&'static str) -> std::io::Result<()>
             ))
             .will_execute(injectorpp::fake!(
                 func_type: fn(path: &str) -> std::io::Result<()>,
@@ -232,8 +229,7 @@ fn test_will_execute_when_fake_generic_function_multiple_types_should_success() 
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func,
-            fn(&'static str, bool, i32) -> String
+            fn (complex_generic_multiple_types_func)(&'static str, bool, i32) -> String
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &str, b: bool, c: i32) -> String,
@@ -255,8 +251,7 @@ fn test_will_execute_when_fake_single_reference_param_function_should_success() 
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            single_reference_param_func,
-            fn(&mut i32) -> bool
+            fn (single_reference_param_func)(&mut i32) -> bool
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &mut i32) -> bool,
@@ -277,8 +272,7 @@ fn test_will_execute_when_fake_single_reference_param_no_return_function_should_
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            single_reference_param_no_return_func,
-            fn(&mut i32) -> ()
+            fn (single_reference_param_no_return_func)(&mut i32) -> ()
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &mut i32) -> (),
@@ -297,8 +291,7 @@ fn test_will_execute_when_fake_multiple_reference_param_function_should_success(
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            multiple_reference_params_func,
-            fn(&mut i32, &mut bool) -> bool
+            fn (multiple_reference_params_func)(&mut i32, &mut bool) -> bool
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &mut i32, b: &mut bool) -> bool,
@@ -322,8 +315,7 @@ fn test_will_execute_when_fake_multiple_reference_param_no_return_function_shoul
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            multiple_reference_params_no_return_func,
-            fn(&mut i32, &mut bool) -> ()
+            fn (multiple_reference_params_no_return_func)(&mut i32, &mut bool) -> ()
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &mut i32, b: &mut bool) -> (),
@@ -344,7 +336,7 @@ fn test_will_execute_when_fake_multiple_reference_param_no_return_function_shoul
 fn test_will_execute_when_fake_file_dependency_should_success_times() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Path::is_dir, fn(&Path) -> bool))
+        .when_called(injectorpp::func!(fn (Path::is_dir)(&Path) -> bool))
         .will_execute(injectorpp::fake!(
             func_type: fn(_path: &Path) -> bool,
             returns: true,
@@ -360,7 +352,7 @@ fn test_will_execute_when_fake_file_dependency_should_success_times() {
 fn test_will_execute_when_fake_method_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Foo::bar, fn(&Foo) -> i32))
+        .when_called(injectorpp::func!(fn (Foo::bar)(&Foo) -> i32))
         .will_execute(injectorpp::fake!(
             func_type: fn(_f: &Foo) -> i32,
             returns: 1
@@ -376,7 +368,7 @@ fn test_will_execute_when_fake_method_should_success() {
 fn test_will_execute_when_fake_method_with_parameter_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Foo::add, fn(&Foo, i32) -> i32))
+        .when_called(injectorpp::func!(fn (Foo::add)(&Foo, i32) -> i32))
         .will_execute(injectorpp::fake!(
             func_type: fn(f: &Foo, value: i32) -> i32,
             when: f.value > 0,
@@ -394,8 +386,7 @@ fn test_will_execute_when_fake_method_with_output_parameter_no_return_should_suc
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            Foo::add_no_return,
-            fn(&Foo, i32, &mut i32) -> ()
+            fn (Foo::add_no_return)(&Foo, i32, &mut i32) -> ()
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(f: &Foo, value: i32, output: &mut i32) -> (),
@@ -416,8 +407,7 @@ fn test_will_execute_when_fake_method_can_recover() {
         let mut injector = InjectorPP::new();
         injector
             .when_called(injectorpp::func!(
-                Foo::add_no_return,
-                fn(&Foo, i32, &mut i32) -> ()
+                fn (Foo::add_no_return)(&Foo, i32, &mut i32) -> ()
             ))
             .will_execute(injectorpp::fake!(
                 func_type: fn(f: &Foo, value: i32, output: &mut i32) -> (),
@@ -461,7 +451,7 @@ fn test_will_execute_fake_unsafe_non_unit_returns_only_should_success() {
 fn test_will_execute_fake_unsafe_non_unit_returns_and_times_over_called_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_non_unit, unsafe fn(i32) -> i32))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_non_unit)(i32) -> i32))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(val: i32) -> i32,
             returns: val + 2,
@@ -481,7 +471,7 @@ fn test_will_execute_fake_unsafe_non_unit_returns_and_times_over_called_should_p
 fn test_will_execute_fake_unsafe_unit_without_times_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_unit, unsafe fn(&mut i32) -> ()))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_unit)(&mut i32) -> ()))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(_x: &mut i32) -> ()
         ));
@@ -501,7 +491,7 @@ fn test_will_execute_fake_unsafe_unit_without_times_should_success() {
 fn test_will_execute_fake_unsafe_unit_with_times_over_called_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_unit, unsafe fn(&mut i32) -> ()))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_unit)(&mut i32) -> ()))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(_x: &mut i32) -> (),
             times: 1
@@ -523,7 +513,7 @@ fn test_will_execute_fake_unsafe_unit_with_times_over_called_should_panic() {
 fn test_will_execute_fake_unsafe_unit_with_assign_only_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_unit, unsafe fn(&mut i32) -> ()))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_unit)(&mut i32) -> ()))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(x: &mut i32) -> (),
             assign: { *x += 5 }
@@ -539,7 +529,7 @@ fn test_will_execute_fake_unsafe_unit_with_assign_only_should_success() {
 fn test_will_execute_fake_unsafe_unit_with_assign_and_times_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_unit, unsafe fn(&mut i32) -> ()))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_unit)(&mut i32) -> ()))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(x: &mut i32) -> (),
             assign: { *x += 2 },
@@ -558,7 +548,7 @@ fn test_will_execute_fake_unsafe_unit_with_assign_and_times_should_success() {
 fn test_will_execute_fake_unsafe_unit_assign_and_times_over_called_should_panic() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(unsafe_unit, unsafe fn(&mut i32) -> ()))
+        .when_called(injectorpp::func!(unsafe{} fn (unsafe_unit)(&mut i32) -> ()))
         .will_execute(injectorpp::fake!(
             func_type: unsafe fn(x: &mut i32) -> (),
             assign: { *x += 3 },

--- a/tests/will_execute_raw.rs
+++ b/tests/will_execute_raw.rs
@@ -54,8 +54,8 @@ fn test_will_execute_raw_when_fake_no_return_function_should_success() {
 
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(func_no_return, fn()))
-        .will_execute_raw(injectorpp::func!(fake_func_no_return, fn()));
+        .when_called(injectorpp::func!(fn (func_no_return)()))
+        .will_execute_raw(injectorpp::func!(fn (fake_func_no_return)()));
 
     func_no_return();
 
@@ -74,7 +74,7 @@ fn test_will_execute_raw_when_fake_no_return_function_use_closure_should_success
 
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(func_no_return, fn()))
+        .when_called(injectorpp::func!(fn (func_no_return)()))
         .will_execute_raw(injectorpp::closure!(fake_closure, fn()));
 
     func_no_return();
@@ -94,8 +94,7 @@ fn test_will_execute_raw_when_fake_generic_function_single_type_should_success()
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_single_type_always_fail_func,
-            fn(&'static str) -> std::io::Result<()>
+            fn (complex_generic_single_type_always_fail_func)(&'static str) -> std::io::Result<()>
         ))
         .will_execute_raw(injectorpp::closure!(
             fake_closure,
@@ -165,8 +164,7 @@ fn test_will_execute_raw_when_fake_generic_function_multiple_types_with_differen
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func,
-            fn(&'static str, bool, i32) -> String
+            fn (complex_generic_multiple_types_func)(&'static str, bool, i32) -> String
         ))
         .will_execute_raw(injectorpp::closure!(
             fake_closure,

--- a/tests/will_execute_raw.rs
+++ b/tests/will_execute_raw.rs
@@ -39,8 +39,8 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
 fn test_will_execute_raw_when_fake_file_dependency_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(Path::exists, fn(&Path) -> bool))
-        .will_execute_raw(injectorpp::func!(fake_path_exists, fn(&Path) -> bool));
+        .when_called(injectorpp::func!(fn (Path::exists)(&Path) -> bool))
+        .will_execute_raw(injectorpp::func!(fn (fake_path_exists)(&Path) -> bool));
 
     let test_path = "/path/that/does/not/exist";
     let result = Path::new(test_path).exists();
@@ -120,8 +120,7 @@ fn test_will_execute_raw_when_fake_generic_function_multiple_types_should_succes
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func,
-            fn(&'static str, bool, i32) -> String
+            fn (complex_generic_multiple_types_func)(&'static str, bool, i32) -> String
         ))
         .will_execute_raw(injectorpp::closure!(
             fake_closure,

--- a/tests/will_return.rs
+++ b/tests/will_return.rs
@@ -27,7 +27,7 @@ fn test_will_return_boolean_when_in_scope_should_restore() {
     {
         let mut injector = InjectorPP::new();
         injector
-            .when_called(injectorpp::func!(returns_false_in_scope, fn() -> bool))
+            .when_called(injectorpp::func!(fn (returns_false_in_scope)() -> bool))
             .will_return_boolean(true);
 
         let result = returns_false_in_scope();
@@ -43,7 +43,7 @@ fn test_will_return_boolean_when_in_scope_should_restore() {
 fn test_will_return_boolean_when_fake_return_true_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(returns_false, fn() -> bool))
+        .when_called(injectorpp::func!(fn (returns_false)() -> bool))
         .will_return_boolean(true);
 
     let result = returns_false();
@@ -55,7 +55,7 @@ fn test_will_return_boolean_when_fake_return_true_should_success() {
 fn test_will_return_boolean_when_fake_return_false_should_success() {
     let mut injector = InjectorPP::new();
     injector
-        .when_called(injectorpp::func!(returns_false, fn() -> bool))
+        .when_called(injectorpp::func!(fn (returns_false)() -> bool))
         .will_return_boolean(false);
 
     let result = returns_false();
@@ -68,8 +68,7 @@ fn test_will_return_boolean_when_fake_complex_generic_function_multiple_types_sh
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func_return_false,
-            fn(i32, bool, &'static str) -> bool
+            fn (complex_generic_multiple_types_func_return_false)(i32, bool, &'static str) -> bool
         ))
         .will_return_boolean(true);
 
@@ -84,8 +83,7 @@ fn test_will_return_boolean_when_fake_complex_generic_function_multiple_types_an
     let mut injector = InjectorPP::new();
     injector
         .when_called(injectorpp::func!(
-            complex_generic_multiple_types_func_return_false,
-            fn(i32, bool, &'static str) -> bool
+            fn (complex_generic_multiple_types_func_return_false)(i32, bool, &'static str) -> bool
         ))
         .will_return_boolean(true);
 


### PR DESCRIPTION
Simplify `func!` macro usage to support type check.