### PR TITLE
perf: optimize amd64  and reduce duplication

### DIFF
--- a/src/injector_core/patch_amd64.rs
+++ b/src/injector_core/patch_amd64.rs
@@ -3,8 +3,10 @@
 use crate::injector_core::common::*;
 use crate::injector_core::patch_trait::*;
 
+/// Patch implementation for AMD64 (x86_64) architecture.
 pub(crate) struct PatchAmd64;
 
+/// Opcode constants for AMD64 jump and move instructions.
 const JMP_REL_OPCODE: u8 = 0xE9;
 const MOV_RAX_OPCODE: [u8; 2] = [0x48, 0xB8];
 const JMP_RAX_OPCODE: [u8; 2] = [0xFF, 0xE0];
@@ -14,102 +16,82 @@ impl PatchTrait for PatchAmd64 {
         src: FuncPtrInternal,
         target: FuncPtrInternal,
     ) -> PatchGuard {
-        // The code size is maximum 12 bytes because only a jmp instruction is needed.
-        let jit_size = 12;
-        let jit_memory = allocate_jit_memory(&src, jit_size);
+        const JIT_SIZE: usize = 12;
+        let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
 
         let target_addr = target.as_ptr() as usize;
         let jit_addr = jit_memory as usize;
 
-        // The jit code is simply jumping to the target address.
         let jit_code = generate_branch_to_target_function(jit_addr, target_addr);
 
-        // Write the jit code to the jit memory.
         unsafe {
             inject_asm_code(&jit_code, jit_memory);
         }
 
-        // Now modify the original function to branch to the jit memory
-        let func_addr = src.as_ptr() as usize;
-
-        let branch_code = generate_branch_to_target_function(func_addr, jit_addr);
-
-        let patch_size = branch_code.len();
-        let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, patch_size) };
-
-        unsafe {
-            patch_function(src.as_ptr() as *mut u8, &branch_code);
-        }
-
-        PatchGuard::new(
-            src.as_ptr() as *mut u8,
-            original_bytes,
-            patch_size,
-            jit_memory,
-            jit_size,
-        )
+        patch_and_guard(src, jit_memory, JIT_SIZE)
     }
 
     fn replace_function_return_boolean(src: FuncPtrInternal, value: bool) -> PatchGuard {
-        let jit_size = 8;
-        let jit_memory = allocate_jit_memory(&src, jit_size);
+        const JIT_SIZE: usize = 8;
+        let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
 
         generate_will_return_boolean_jit_code(jit_memory, value);
 
-        let func_addr = src.as_ptr() as usize;
-        let jit_addr = jit_memory as usize;
-
-        let branch_code = generate_branch_to_target_function(func_addr, jit_addr);
-
-        let patch_size = branch_code.len();
-        let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, patch_size) };
-
-        unsafe {
-            patch_function(src.as_ptr() as *mut u8, &branch_code);
-        }
-
-        PatchGuard::new(
-            src.as_ptr() as *mut u8,
-            original_bytes,
-            patch_size,
-            jit_memory,
-            jit_size,
-        )
+        patch_and_guard(src, jit_memory, JIT_SIZE)
     }
 }
 
+/// Injects a return-boolean JIT sequence at `jit_ptr`.
 fn generate_will_return_boolean_jit_code(jit_ptr: *mut u8, value: bool) {
-    let mut asm_code: Vec<u8> = vec![
-        // mov rax, 0x00;
-        // ret;
-        0x48, 0xC7, 0xC0, 0x00, 0x00, 0x00, 0x00, 0xC3,
+    let mut asm_code: [u8; 8] = [
+        0x48, 0xC7, 0xC0, // mov rax, imm32
+        0x00, 0x00, 0x00, 0x00, // imm32
+        0xC3, // ret
     ];
 
-    // Replace the value accordingly
-    if value {
-        asm_code[3] = 1u8;
-    }
+    asm_code[3] = value as u8;
 
     unsafe {
         inject_asm_code(&asm_code, jit_ptr);
     }
 }
 
+/// Generates a jump from `ori_func` to `target_func`.
 fn generate_branch_to_target_function(ori_func: usize, target_func: usize) -> Vec<u8> {
     let offset = target_func as isize - (ori_func as isize + 5);
 
     if offset >= i32::MIN as isize && offset <= i32::MAX as isize {
-        // Emit: jmp rel32 (5 bytes)
         let mut branch_code = Vec::with_capacity(5);
         branch_code.push(JMP_REL_OPCODE);
         branch_code.extend_from_slice(&(offset as i32).to_le_bytes());
         branch_code
     } else {
-        // Emit: mov rax, imm64 + jmp rax (13 bytes)
         let mut branch_code = Vec::with_capacity(13);
         branch_code.extend_from_slice(&MOV_RAX_OPCODE);
         branch_code.extend_from_slice(&(target_func as u64).to_le_bytes());
         branch_code.extend_from_slice(&JMP_RAX_OPCODE);
         branch_code
     }
+}
+
+fn patch_and_guard(src: FuncPtrInternal, jit_memory: *mut u8, jit_size: usize) -> PatchGuard {
+    let func_addr = src.as_ptr() as usize;
+    let jit_addr = jit_memory as usize;
+
+    let branch_code = generate_branch_to_target_function(func_addr, jit_addr);
+    let patch_size = branch_code.len();
+
+    let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, patch_size) };
+
+    unsafe {
+        patch_function(src.as_ptr() as *mut u8, &branch_code);
+    }
+
+    PatchGuard::new(
+        src.as_ptr() as *mut u8,
+        original_bytes,
+        patch_size,
+        jit_memory,
+        jit_size,
+    )
 }


### PR DESCRIPTION
- This pr try to improves the impl of the PatchAmd64 backend by :


 1- replacing vec alloc in `generate_will_return_boolean_jit_code` with fixed size `[u8; 8]`
 2- used asm_code[3] = value as u8 to simplify conditional logic
 3- added patch_and_guard() helper to eliminate duplicated


**Note** : _No functional behavior change_