### PR TITLE
Fix :  Restrict ±128MB JIT allocation range on Windows to AArch64 only

### DIFF
--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -98,7 +98,7 @@ fn allocate_jit_memory_windows(_src: &FuncPtrInternal, code_size: usize) -> *mut
     #[cfg(target_arch = "aarch64")]
     {
         let max_range: u64 = 0x8000000; // ±128MB
-        let original_addr = src.as_ptr() as u64;
+        let original_addr = _src.as_ptr() as u64;
         let page_size = unsafe { get_page_size() as u64 };
         let mut start_address = original_addr.saturating_sub(max_range);
 

--- a/src/injector_core/common.rs
+++ b/src/injector_core/common.rs
@@ -94,7 +94,7 @@ fn allocate_jit_memory_linux(src: &FuncPtrInternal, code_size: usize) -> *mut u8
 /// For AArch64, memory must be within ±128MB due to instruction encoding limits (e.g., B/BL).
 /// For x86_64, this restriction doesn't apply — use `null_mut()` as base hint.
 #[cfg(target_os = "windows")]
-fn allocate_jit_memory_windows(src: &FuncPtrInternal, code_size: usize) -> *mut u8 {
+fn allocate_jit_memory_windows(_src: &FuncPtrInternal, code_size: usize) -> *mut u8 {
     #[cfg(target_arch = "aarch64")]
     {
         let max_range: u64 = 0x8000000; // ±128MB


### PR DESCRIPTION
Closes https://github.com/microsoft/injectorppforrust/issues/84

- Applied the ±128MB mem only on aarch64 targets for Windows
- non-AArch64 targets now use **VirtualAlloc(null_mut())** without range scanning