### PR TITLE
Add a feature to prevent injectorpp instance creation

### DIFF
--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -82,6 +82,13 @@ impl InjectorPP {
         }
     }
 
+    /// Prevents injectorpp from other threads to change the functions.
+    /// This is useful when the test does not want to be affected by injectorpp usage in other threads.
+    pub fn prevent() -> Preventer {
+        let lock = LOCK_FUNCTION.lock();
+        Preventer { _lock: lock }
+    }
+
     /// Begins faking a function.
     ///
     /// Accepts a FuncPtr to the function you want to fake. Use the `func!` macro to obtain this pointer.
@@ -279,6 +286,20 @@ impl InjectorPP {
 impl Default for InjectorPP {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub struct Preventer {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl Preventer {
+    /// Check if patching is currently prevented by this guard.
+    ///
+    /// This always returns `true` while the guard exists, as the guard
+    /// holds the global mutex that prevents patching.
+    pub fn is_active(&self) -> bool {
+        true
     }
 }
 

--- a/src/interface/injector.rs
+++ b/src/interface/injector.rs
@@ -289,6 +289,11 @@ impl Default for InjectorPP {
     }
 }
 
+/// A guard that prevents injectorpp affecting the test while alive.
+///
+/// When this guard is held, no any injectorpp instance can be created.
+/// This is useful for threads that need to call functions with their
+/// original behavior.
 pub struct Preventer {
     _lock: MutexGuard<'static, ()>,
 }

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -10,7 +10,7 @@ pub fn foo() -> i32 {
 fn test_multi_thread_function_call() {
     let handle = thread::spawn(move || {
         for _ in 0..1000 {
-            InjectorPP::prevent();
+            let _guard = InjectorPP::prevent();
 
             assert_eq!(foo(), 6);
         }
@@ -26,4 +26,21 @@ fn test_multi_thread_function_call() {
     }
 
     handle.join().unwrap();
+}
+
+#[test]
+fn test_original_function_call() {
+    let _guard = InjectorPP::prevent();
+
+    assert_eq!(foo(), 6);
+}
+
+#[test]
+fn test_faked_function_call() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(fn (foo)() -> i32))
+        .will_execute_raw(injectorpp::closure!(|| { 9 }, fn() -> i32));
+
+    assert_eq!(foo(), 9);
 }

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -1,0 +1,29 @@
+use injectorpp::interface::injector::*;
+use std::thread;
+
+#[inline(never)]
+pub fn foo() -> i32 {
+    6
+}
+
+#[test]
+fn test_multi_thread_function_call() {
+    let handle = thread::spawn(move || {
+        for _ in 0..1000 {
+            InjectorPP::prevent();
+
+            assert_eq!(foo(), 6);
+        }
+    });
+
+    for _ in 0..10 {
+        let mut injector = InjectorPP::new();
+        injector
+            .when_called(injectorpp::func!(fn (foo)() -> i32))
+            .will_execute_raw(injectorpp::closure!(|| { 9 }, fn() -> i32));
+
+        assert_eq!(foo(), 9);
+    }
+
+    handle.join().unwrap();
+}


### PR DESCRIPTION
The function faked by injectorpp is per process. `cargo test` by default runs tests in multi threads. This can cause race condition. Adding a feature to allow preventing injectorpp affecting a test that does not need to fake any function by using injectorpp.