### PR TITLE
refactor(patch_arm64): deduplicate patching with helper

### DIFF
--- a/src/injector_core/patch_arm64.rs
+++ b/src/injector_core/patch_arm64.rs
@@ -9,32 +9,29 @@ pub(crate) struct PatchArm64;
 
 impl PatchTrait for PatchArm64 {
     fn replace_function_with_other_function(
-    src: FuncPtrInternal,
-    target: FuncPtrInternal,
-) -> PatchGuard {
-    const PATCH_SIZE: usize = 12;
-    const JIT_SIZE: usize = 20;
+        src: FuncPtrInternal,
+        target: FuncPtrInternal,
+    ) -> PatchGuard {
+        const PATCH_SIZE: usize = 12;
+        const JIT_SIZE: usize = 20;
 
-    let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
-    let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
-    generate_will_execute_jit_code_abs(jit_memory, target.as_ptr());
+        let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
+        let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
+        generate_will_execute_jit_code_abs(jit_memory, target.as_ptr());
 
-    apply_branch_patch(src, jit_memory, JIT_SIZE, &original_bytes)
-}
+        apply_branch_patch(src, jit_memory, JIT_SIZE, &original_bytes)
+    }
 
-
-    
     fn replace_function_return_boolean(src: FuncPtrInternal, value: bool) -> PatchGuard {
-    const PATCH_SIZE: usize = 12;
-    const JIT_SIZE: usize = 8;
+        const PATCH_SIZE: usize = 12;
+        const JIT_SIZE: usize = 8;
 
-    let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
-    let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
-    generate_will_return_boolean_jit_code(jit_memory, value);
+        let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
+        let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
+        generate_will_return_boolean_jit_code(jit_memory, value);
 
-    apply_branch_patch(src, jit_memory, JIT_SIZE, &original_bytes)
-}
-
+        apply_branch_patch(src, jit_memory, JIT_SIZE, &original_bytes)
+    }
 }
 
 /// Generates a 16-byte JIT code block that loads the absolute address of `target`
@@ -115,7 +112,6 @@ fn append_instruction(asm_code: &mut Vec<u8>, instruction: u32) {
     asm_code.push(((instruction >> 24) & 0xFF) as u8);
 }
 
-
 fn apply_branch_patch(
     src: FuncPtrInternal,
     jit_memory: *mut u8,
@@ -131,9 +127,7 @@ fn apply_branch_patch(
     let offset = (jit_addr as isize - func_addr as isize) / 4;
 
     if !BRANCH_RANGE.contains(&offset) {
-        panic!(
-            "JIT memory is out of branch range: offset = {offset}, expected ±32MB"
-        );
+        panic!("JIT memory is out of branch range: offset = {offset}, expected ±32MB");
     }
 
     let branch_instr: u32 = 0x14000000 | ((offset as u32) & 0x03FF_FFFF);
@@ -147,5 +141,11 @@ fn apply_branch_patch(
         patch_function(src.as_ptr() as *mut u8, &patch);
     }
 
-    PatchGuard::new(src.as_ptr() as *mut u8, original_bytes.to_vec(), PATCH_SIZE, jit_memory, jit_size)
+    PatchGuard::new(
+        src.as_ptr() as *mut u8,
+        original_bytes.to_vec(),
+        PATCH_SIZE,
+        jit_memory,
+        jit_size,
+    )
 }


### PR DESCRIPTION
This pr is for  the function of replace_function_with_other_function and  the function replace_function_return_boolean 

The PR aim to share a new helper 


The helper is supposed to handles : 
- offset calculation
-  branch encoding 
- patching logic for AArch64.





