### PR TITLE
feat: check entry size before patching to avoid UB

### DIFF
--- a/src/injector_core/patch_arm64.rs
+++ b/src/injector_core/patch_arm64.rs
@@ -15,6 +15,11 @@ impl PatchTrait for PatchArm64 {
         const PATCH_SIZE: usize = 12;
         const JIT_SIZE: usize = 20;
 
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        unsafe {
+            assert_min_patch_window_or_panic(&src, PATCH_SIZE);
+        }
+
         let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
         let jit_memory = allocate_jit_memory(&src, JIT_SIZE);
         generate_will_execute_jit_code_abs(jit_memory, target.as_ptr());
@@ -25,6 +30,11 @@ impl PatchTrait for PatchArm64 {
     fn replace_function_return_boolean(src: FuncPtrInternal, value: bool) -> PatchGuard {
         const PATCH_SIZE: usize = 12;
         const JIT_SIZE: usize = 8;
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        unsafe {
+            assert_min_patch_window_or_panic(&src, PATCH_SIZE);
+        }
 
         let original_bytes = unsafe { read_bytes(src.as_ptr() as *mut u8, PATCH_SIZE) };
         let jit_memory = allocate_jit_memory(&src, JIT_SIZE);

--- a/tests/fn_too_small.rs
+++ b/tests/fn_too_small.rs
@@ -1,0 +1,40 @@
+#![cfg(all(target_os = "linux", target_arch = "aarch64"))]
+
+
+
+use injectorpp::interface::injector::*;
+
+#[inline(never)]
+#[no_mangle] 
+fn ret_only() {
+}
+
+
+#[inline(never)]
+#[no_mangle]
+fn returns_false() -> bool {
+    false
+}
+
+/// Should panic because the very first instruction is `RET` at +0.
+#[test]
+#[should_panic(expected = "Target function too small")]
+fn panics_on_ret_at_entry() {
+    let mut injector = InjectorPP::new();
+
+
+    injector
+        .when_called(injectorpp::func!(fn (ret_only)() -> ()))
+        .will_execute_raw(injectorpp::closure!(|| {}, fn()));
+}
+
+
+#[test]
+#[should_panic(expected = "Target function too small")]
+fn panics_on_ret_within_window() {
+    let mut injector = InjectorPP::new();
+
+    injector
+        .when_called(injectorpp::func!(fn (returns_false)() -> bool))
+        .will_return_boolean(true); 
+}


### PR DESCRIPTION
## Summary

- Add an **entry-window safety check** on Linux AArch64 to prevent patching functions whose first bytes are smaller than the patch window, which can cause undefined behavior.


## What changed
- Introduced `assert_min_patch_window_or_panic` and call it at the start of:
  - `replace_function_with_other_function`
  - `replace_function_return_boolean`
- The check reads exactly the first `PATCH_SIZE` bytes and validates they are safe to overwrite.

- Allow `B imm26` at `+0`
- Panic if `RET` appears anywhere within the first `PATCH_SIZE` bytes.
- Panic if `BR Xn` appears anywhere within the first `PATCH_SIZE` bytes.
- Panic if `B imm26` appears at `+4` or `+8`.


- Other platforms and existing code paths (including macOS long-jump handling) are unchanged.


## Impact on tests
- Tests that patch very small functions may now panic on Linux AArch64 because `RET` falls within the 12-byte window.



##  Questions
- Is the rule for `B imm26` acceptable (allow only at `+0`, reject at `+4/+8`)?


