### PR TITLE
fix: enforce clippy warnings as CI failures

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -45,8 +45,12 @@ jobs:
         run:
           cargo clippy
           --all-features
+          --all-targets
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
+
+      - name: Fail on clippy warnings
+        run: cargo clippy --all-features --all-targets -- -D warnings
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -480,7 +480,7 @@ macro_rules! fake {
          use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if $cond {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
@@ -504,13 +504,12 @@ macro_rules! fake {
          use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if $cond {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
-                 ()
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
@@ -526,14 +525,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
          let verifier = CallCountVerifier::Dummy;
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if $cond {
                  { $($assign)* }
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
          }
-         let f: fn($($arg_ty),*) -> () = fake;
+         let f: fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -543,14 +542,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
          let verifier = CallCountVerifier::Dummy;
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if true {
                  { $($assign)* }
              } else {
                 unreachable!()
              }
          }
-         let f: fn($($arg_ty),*) -> () = fake;
+         let f: fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -564,19 +563,18 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
                  { $($assign)* }
-                 ()
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
          }
-         let f: fn($($arg_ty),*) -> () = fake;
+         let f: fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -588,18 +586,17 @@ macro_rules! fake {
          use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         fn fake($($arg_name: $arg_ty),*) -> () {
+         fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
-                 ()
              } else {
                  unreachable!()
              }
          }
-         let f: fn($($arg_ty),*) -> () = fake;
+         let f: fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -608,10 +605,10 @@ macro_rules! fake {
         func_type: fn($($arg_name:ident: $arg_ty:ty),*) -> ()
     ) => {{
          let verifier = CallCountVerifier::Dummy;
-         fn fake($($arg_name: $arg_ty),*) -> () {
-             if true { () } else { unreachable!() }
+         fn fake($($arg_name: $arg_ty),*) {
+             if true { } else { unreachable!() }
          }
-         let f: fn($($arg_ty),*) -> () = fake;
+         let f: fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -712,18 +709,17 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
         let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-        unsafe fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe fn fake($($arg_name: $arg_ty),*) {
             if true {
                 let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                 if prev >= $expected {
                     panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                 }
-                ()
             } else {
                 unreachable!()
             }
         }
-        let f: unsafe fn($($arg_ty),*) -> () = fake;
+        let f: unsafe fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -733,14 +729,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe fn fake($($arg_name: $arg_ty),*) {
             if true {
                 { $($assign)* }
             } else {
                 unreachable!()
             }
         }
-        let f: unsafe fn($($arg_ty),*) -> () = fake;
+        let f: unsafe fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -754,19 +750,18 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         unsafe fn fake($($arg_name: $arg_ty),*) -> () {
+         unsafe fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
                  { $($assign)* }
-                 ()
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
          }
-         let f: unsafe fn($($arg_ty),*) -> () = fake;
+         let f: unsafe fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -775,10 +770,10 @@ macro_rules! fake {
         func_type: unsafe fn($($arg_name:ident: $arg_ty:ty),*) -> ()
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe fn fake($($arg_name: $arg_ty),*) -> () {
-            if true { () } else { unreachable!() }
+        unsafe fn fake($($arg_name: $arg_ty),*) {
+            if true { } else { unreachable!() }
         }
-        let f: unsafe fn($($arg_ty),*) -> () = fake;
+        let f: unsafe fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -936,7 +931,7 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
         let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                 if prev >= $expected {
@@ -947,7 +942,7 @@ macro_rules! fake {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "C" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -960,18 +955,17 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
         let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                 if prev >= $expected {
                     panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                 }
-                ()
             } else {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "C" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -982,14 +976,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 { $($assign)* }
             } else {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "C" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -999,14 +993,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
             if true {
                 { $($assign)* }
             } else {
                 unreachable!()
             }
         }
-        let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "C" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1020,19 +1014,18 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
                  { $($assign)* }
-                 ()
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
          }
-         let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "C" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1044,18 +1037,17 @@ macro_rules! fake {
          use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
+         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
-                 ()
              } else {
                  unreachable!()
              }
          }
-         let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "C" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1064,10 +1056,10 @@ macro_rules! fake {
         func_type: unsafe extern "C" fn($($arg_name:ident: $arg_ty:ty),*) -> ()
     ) => {{
          let verifier = CallCountVerifier::Dummy;
-         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) -> () {
-             if true { () } else { unreachable!() }
+         unsafe extern "C" fn fake($($arg_name: $arg_ty),*) {
+             if true { } else { unreachable!() }
          }
-         let f: unsafe extern "C" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "C" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1240,7 +1232,7 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
         let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                 if prev >= $expected {
@@ -1251,7 +1243,7 @@ macro_rules! fake {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "system" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1264,18 +1256,17 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
         static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
         let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                 if prev >= $expected {
                     panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                 }
-                ()
             } else {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "system" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1286,14 +1277,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
             if $cond {
                 { $($assign)* }
             } else {
                 panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
             }
         }
-        let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "system" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1303,14 +1294,14 @@ macro_rules! fake {
         assign: { $($assign:tt)* }
     ) => {{
         let verifier = CallCountVerifier::Dummy;
-        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+        unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
             if true {
                 { $($assign)* }
             } else {
                 unreachable!()
             }
         }
-        let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+        let f: unsafe extern "system" fn($($arg_ty),*) = fake;
         let raw_ptr = f as *const ();
         (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1324,19 +1315,18 @@ macro_rules! fake {
         use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
                  { $($assign)* }
-                 ()
              } else {
                  panic!("Fake function defined at {}:{}:{} called with unexpected arguments", file!(), line!(), column!());
              }
          }
-         let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "system" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1348,18 +1338,17 @@ macro_rules! fake {
          use std::sync::atomic::{AtomicUsize, Ordering};
          static FAKE_COUNTER: AtomicUsize = AtomicUsize::new(0);
          let verifier = CallCountVerifier::WithCount { counter: &FAKE_COUNTER, expected: $expected };
-         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
+         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
              if true {
                  let prev = FAKE_COUNTER.fetch_add(1, Ordering::SeqCst);
                  if prev >= $expected {
                      panic!("Fake function defined at {}:{}:{} called more times than expected", file!(), line!(), column!());
                  }
-                 ()
              } else {
                  unreachable!()
              }
          }
-         let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "system" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};
@@ -1368,10 +1357,10 @@ macro_rules! fake {
         func_type: unsafe extern "system" fn($($arg_name:ident: $arg_ty:ty),*) -> ()
     ) => {{
          let verifier = CallCountVerifier::Dummy;
-         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) -> () {
-             if true { () } else { unreachable!() }
+         unsafe extern "system" fn fake($($arg_name: $arg_ty),*) {
+             if true { } else { unreachable!() }
          }
-         let f: unsafe extern "system" fn($($arg_ty),*) -> () = fake;
+         let f: unsafe extern "system" fn($($arg_ty),*) = fake;
          let raw_ptr = f as *const ();
          (unsafe { FuncPtr::new(raw_ptr, std::any::type_name_of_val(&f)) }, verifier)
     }};

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -57,7 +57,7 @@ async fn test_simple_async_func_should_success() {
 
     // simple_async_func_bool should not be affected
     let y = simple_async_func_bool(true).await;
-    assert_eq!(y, true);
+    assert!(y);
 
     injector
         .when_called_async(injectorpp::async_func!(
@@ -68,7 +68,7 @@ async fn test_simple_async_func_should_success() {
 
     // Now because it's faked the return value should be false
     let y = simple_async_func_bool(true).await;
-    assert_eq!(y, false);
+    assert!(!y);
 }
 
 #[tokio::test]

--- a/tests/async_unchecked.rs
+++ b/tests/async_unchecked.rs
@@ -59,7 +59,7 @@ async fn test_simple_async_func_unchecked_should_success() {
 
     // simple_async_func_bool should not be affected
     let y = simple_async_func_bool(true).await;
-    assert_eq!(y, true);
+    assert!(y);
 
     unsafe {
         injector
@@ -71,7 +71,7 @@ async fn test_simple_async_func_unchecked_should_success() {
 
     // Now because it's faked the return value should be false
     let y = simple_async_func_bool(true).await;
-    assert_eq!(y, false);
+    assert!(!y);
 }
 
 #[tokio::test]

--- a/tests/azure.rs
+++ b/tests/azure.rs
@@ -10,13 +10,13 @@ use azure_core::http::{new_http_client, Method, Request, Url};
 async fn test_azure_http_client_always_return_200() {
     // Create a temporary client + request to capture the method pointer
     let temp_client = new_http_client();
-    let mut temp_req = Request::new(Url::parse("https://temp/").unwrap(), Method::Get);
+    let temp_req = Request::new(Url::parse("https://temp/").unwrap(), Method::Get);
 
     // Setup the fake
     let mut injector = InjectorPP::new();
     injector
         .when_called_async(injectorpp::async_func!(
-            temp_client.execute_request(&mut temp_req),
+            temp_client.execute_request(&temp_req),
             std::result::Result<RawResponse, Error>
         ))
         .will_return_async(injectorpp::async_return!(
@@ -28,8 +28,8 @@ async fn test_azure_http_client_always_return_200() {
     // Run the real code under test
     let client = new_http_client();
     let url = Url::parse("https://nonexistsitetest").unwrap();
-    let mut request = Request::new(url, Method::Get);
+    let request = Request::new(url, Method::Get);
 
-    let response = client.execute_request(&mut request).await.unwrap();
+    let response = client.execute_request(&request).await.unwrap();
     assert_eq!(response.status(), 200);
 }

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -10,7 +10,7 @@ async fn simple_async_func_u32_add_one(x: u32) -> u32 {
 }
 
 pub fn return_string() -> String {
-    return "Hello, world!".to_string();
+    "Hello, world!".to_string()
 }
 
 fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
@@ -18,7 +18,7 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
     _b: B,
     _c: C,
 ) -> String {
-    return "Original value".to_string();
+    "Original value".to_string()
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_will_execute_when_generic_function_multiple_types_signature_mismatch_sho
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &str, b: bool) -> String,
-            when: a == "abc" && b == true,
+            when: a == "abc" && b,
             returns: "Fake value".to_string(),
             times: 1
         ));

--- a/tests/will_execute.rs
+++ b/tests/will_execute.rs
@@ -26,7 +26,7 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
     _b: B,
     _c: C,
 ) -> String {
-    return "Original value".to_string();
+    "Original value".to_string()
 }
 
 fn single_reference_param_no_return_func(a: &mut i32) {
@@ -41,20 +41,24 @@ fn multiple_reference_params_no_return_func(a: &mut i32, b: &mut bool) {
 fn single_reference_param_func(a: &mut i32) -> bool {
     *a = 1;
 
-    return false;
+    false
 }
 
 fn multiple_reference_params_func(a: &mut i32, b: &mut bool) -> bool {
     *a = 1;
     *b = false;
 
-    return false;
+    false
 }
 
+/// # Safety
+/// Test function — no actual invariants.
 pub unsafe fn unsafe_non_unit(a: i32) -> i32 {
     a * 10
 }
 
+/// # Safety
+/// Test function — caller must pass a valid mutable reference.
 pub unsafe fn unsafe_unit(x: &mut i32) {
     *x += 2;
 }
@@ -96,7 +100,7 @@ fn test_will_execute_when_fake_file_dependency_should_success() {
     let test_path = "/path/that/does/not/exist";
     let result = Path::new(test_path).exists();
 
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -156,14 +160,13 @@ fn test_will_execute_when_fake_no_return_function_over_called_should_panic() {
 
     let message = result.unwrap_err();
     let message_str = message
-        .downcast_ref::<&str>()
-        .map(|s| *s)
+        .downcast_ref::<&str>().copied()
         .or_else(|| message.downcast_ref::<String>().map(|s| s.as_str()))
         .unwrap();
 
     assert_eq!(
         message_str,
-        format!("Fake function defined at tests{MAIN_SEPARATOR}will_execute.rs:143:23 called more times than expected")
+        format!("Fake function defined at tests{MAIN_SEPARATOR}will_execute.rs:147:23 called more times than expected")
     );
 }
 
@@ -237,7 +240,7 @@ fn test_will_execute_when_fake_generic_function_multiple_types_should_success() 
         ))
         .will_execute(injectorpp::fake!(
             func_type: fn(a: &'static str, b: bool, c: i32) -> String,
-            when: a == "abc" && b == true && c == 123,
+            when: a == "abc" && b && c == 123,
             returns: "Fake value".to_string(),
             times: 1
         ));
@@ -268,7 +271,7 @@ fn test_will_execute_when_fake_single_reference_param_function_should_success() 
     let result = single_reference_param_func(&mut value);
 
     assert_eq!(value, 6);
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -310,8 +313,8 @@ fn test_will_execute_when_fake_multiple_reference_param_function_should_success(
     let result = multiple_reference_params_func(&mut value1, &mut value2);
 
     assert_eq!(value1, 6);
-    assert_eq!(value2, true);
-    assert_eq!(result, true);
+    assert!(value2);
+    assert!(result);
 }
 
 #[test]
@@ -333,7 +336,7 @@ fn test_will_execute_when_fake_multiple_reference_param_no_return_function_shoul
     multiple_reference_params_no_return_func(&mut value1, &mut value2);
 
     assert_eq!(value1, 6);
-    assert_eq!(value2, true);
+    assert!(value2);
 }
 
 #[test]

--- a/tests/will_execute_raw.rs
+++ b/tests/will_execute_raw.rs
@@ -32,7 +32,7 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
     _b: B,
     _c: C,
 ) -> String {
-    return "Original value".to_string();
+    "Original value".to_string()
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_will_execute_raw_when_fake_file_dependency_should_success() {
     let test_path = "/path/that/does/not/exist";
     let result = Path::new(test_path).exists();
 
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -144,13 +144,13 @@ fn test_will_execute_raw_when_fake_generic_function_multiple_types_with_differen
     static CALL_COUNT_CONDITION_THREE_CLOSURE: AtomicU32 = AtomicU32::new(0);
 
     let fake_closure = |a: &str, b: bool, c: i32| -> String {
-        if b == true && c > 1 {
+        if b && c > 1 {
             CALL_COUNT_CONDITION_ONE_CLOSURE.fetch_add(1, Ordering::SeqCst);
 
             return "Called with condition 1".to_string();
         }
 
-        if a == "cond2" && b == false {
+        if a == "cond2" && !b {
             CALL_COUNT_CONDITION_TWO_CLOSURE.fetch_add(1, Ordering::SeqCst);
 
             return "Called with condition 2".to_string();

--- a/tests/will_execute_raw_unchecked.rs
+++ b/tests/will_execute_raw_unchecked.rs
@@ -32,7 +32,7 @@ fn complex_generic_multiple_types_func<A: Display, B: Display, C: Display>(
     _b: B,
     _c: C,
 ) -> String {
-    return "Original value".to_string();
+    "Original value".to_string()
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_will_execute_raw_unchecked_when_fake_file_dependency_should_success() {
     let test_path = "/path/that/does/not/exist";
     let result = Path::new(test_path).exists();
 
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -159,13 +159,13 @@ fn test_will_execute_raw_unchecked_when_fake_generic_function_multiple_types_wit
     static CALL_COUNT_CONDITION_THREE_CLOSURE: AtomicU32 = AtomicU32::new(0);
 
     let fake_closure = |a: &str, b: bool, c: i32| -> String {
-        if b == true && c > 1 {
+        if b && c > 1 {
             CALL_COUNT_CONDITION_ONE_CLOSURE.fetch_add(1, Ordering::SeqCst);
 
             return "Called with condition 1".to_string();
         }
 
-        if a == "cond2" && b == false {
+        if a == "cond2" && !b {
             CALL_COUNT_CONDITION_TWO_CLOSURE.fetch_add(1, Ordering::SeqCst);
 
             return "Called with condition 2".to_string();

--- a/tests/will_return.rs
+++ b/tests/will_return.rs
@@ -1,15 +1,15 @@
 use injectorpp::interface::injector::*;
 
 pub fn returns_false() -> bool {
-    return false;
+    false
 }
 
 pub fn returns_false_in_scope() -> bool {
-    return false;
+    false
 }
 
 fn complex_generic_multiple_types_func_return_false<A, B, C>(_a: A, _b: B, _c: C) -> bool {
-    return false;
+    false
 }
 
 fn call_with_another_life_time<'a>(s: &'a str) -> bool {
@@ -22,7 +22,7 @@ fn call_with_another_life_time<'a>(s: &'a str) -> bool {
 
 #[test]
 fn test_will_return_boolean_when_in_scope_should_restore() {
-    assert_eq!(returns_false_in_scope(), false);
+    assert!(!returns_false_in_scope());
 
     {
         let mut injector = InjectorPP::new();
@@ -31,12 +31,12 @@ fn test_will_return_boolean_when_in_scope_should_restore() {
             .will_return_boolean(true);
 
         let result = returns_false_in_scope();
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     let restored = returns_false_in_scope();
 
-    assert_eq!(restored, false);
+    assert!(!restored);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_will_return_boolean_when_fake_return_true_should_success() {
 
     let result = returns_false();
 
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn test_will_return_boolean_when_fake_return_false_should_success() {
 
     let result = returns_false();
 
-    assert_eq!(result, false);
+    assert!(!result);
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_will_return_boolean_when_fake_complex_generic_function_multiple_types_sh
 
     let result = complex_generic_multiple_types_func_return_false(1, false, "test string");
 
-    assert_eq!(result, true);
+    assert!(result);
 }
 
 #[test]
@@ -90,5 +90,5 @@ fn test_will_return_boolean_when_fake_complex_generic_function_multiple_types_an
     let my_str = String::from("hello");
     let result = call_with_another_life_time(&my_str);
 
-    assert_eq!(result, true);
+    assert!(result);
 }


### PR DESCRIPTION
Add a strict clippy step to CI that fails on any warning. Fix all pre-existing clippy warnings across the codebase (unused_unit in fake macro, unused_mut in azure.rs, missing Safety docs, and auto-fixed bool_assert_comparison/needless_return/map_clone).