### PR TITLE
Add permissions to workflow files to resolve security warnings

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   diff-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   coverage-matrix:
     name: Coverage on ${{ matrix.os }} / ${{ matrix.target }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit \permissions: contents: read\ to 4 workflow files that were flagged by code scanning (alerts #1, #3, #4, #9).

This follows the principle of least privilege — workflows only get the permissions they need, preventing potential token misuse if a dependency is compromised.

### Files changed
- \.github/workflows/ci.yml\
- \.github/workflows/doc.yml\
- \.github/workflows/coverage.yml\
- \.github/workflows/ci-coverage.yml\

Resolves code scanning alerts: #1, #3, #4, #9