### PR TITLE
Fix #107: support generic functions with reference type parameters in func!

### DIFF
--- a/src/interface/macros.rs
+++ b/src/interface/macros.rs
@@ -19,9 +19,8 @@
 macro_rules! func {
     // Case 1: Generic function — provide function name and types separately
     ($f:ident :: <$($gen:ty),*>, $fn_type:ty) => {{
-        let fn_val:$fn_type = $f::<$($gen),*>;
-        let ptr = fn_val as *const ();
-        let sig = std::any::type_name_of_val(&fn_val);
+        let ptr = $f::<$($gen),*> as *const ();
+        let sig = std::any::type_name::<$fn_type>();
         let type_id = std::any::TypeId::of::<$fn_type>();
 
         unsafe { FuncPtr::new_with_type_id(ptr, sig, type_id) }
@@ -29,9 +28,8 @@ macro_rules! func {
 
     // Case 2: Non-generic function with explicit type
     ($f:expr, $fn_type:ty) => {{
-        let fn_val:$fn_type = $f;
-        let ptr = fn_val as *const ();
-        let sig = std::any::type_name_of_val(&fn_val);
+        let ptr = ($f) as *const ();
+        let sig = std::any::type_name::<$fn_type>();
         let type_id = std::any::TypeId::of::<$fn_type>();
 
         unsafe { FuncPtr::new_with_type_id(ptr, sig, type_id) }

--- a/tests/will_execute.rs
+++ b/tests/will_execute.rs
@@ -572,3 +572,31 @@ fn test_will_execute_fake_unsafe_unit_assign_and_times_over_called_should_panic(
     });
     assert!(result.is_err());
 }
+
+// Generic function where type parameter S appears inside a slice reference.
+// When monomorphized with S = &str, the fn pointer type has different lifetime
+// counts than the explicit fn pointer type (issue #107).
+fn generic_with_ref_type_param<S: AsRef<str>>(
+    _prefix: &str,
+    _items: &[S],
+) -> String {
+    "original".to_string()
+}
+
+#[test]
+fn test_will_execute_generic_func_with_ref_type_param_via_turbofish() {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(
+            generic_with_ref_type_param::<&str>,
+            fn(&str, &[&str]) -> String
+        ))
+        .will_execute(injectorpp::fake!(
+            func_type: fn(_prefix: &str, _items: &[&str]) -> String,
+            returns: "mocked".to_string(),
+            times: 1
+        ));
+
+    let result = generic_with_ref_type_param("hello", &["a", "b"]);
+    assert_eq!(result, "mocked");
+}


### PR DESCRIPTION
## Summary

Fixes #107 by removing the type coercion in `func!` macro's Case 1 and Case 2, which fails for generic functions whose type parameters are reference types.

## Problem

When mocking a generic function like `nix::unistd::execvp<S: AsRef<CStr>>`, the user specifies:
```rust
func!(nix::unistd::execvp, fn(&CStr, &[&CStr]) -> Result<...>)
```

The explicit fn pointer type `fn(&CStr, &[&CStr])` desugars to `for<'a, 'b, 'c> fn(&'a CStr, &'b [&'c CStr])` (3 independent lifetimes). But the monomorphized `execvp::<&CStr>` has `for<'a, 'b> fn(&'a CStr, &'b [&CStr])` (2 lifetimes — the inner reference's lifetime is tied to the generic parameter). Rust's type system rejects this coercion.

## Fix

Replace the type coercion (`let fn_val: $fn_type = $f`) with a direct cast to `*const ()` and use `type_name::<$fn_type>()` for the signature string. This:

- Avoids the lifetime coercion entirely
- Produces identical signature strings (both are fn pointer type names)
- Preserves TypeId-based type safety checking
- Is fully backward compatible — all 132 tests pass

For generic functions with reference type params, users provide turbofish:
```rust
func!(execvp::<&CStr>, fn(&CStr, &[&CStr]) -> Result<...>)
```

## Testing

- Added `test_will_execute_generic_func_with_ref_type_param_via_turbofish` — reproduces the exact issue #107 pattern
- All 132 tests pass (131 existing + 1 new), clippy clean

Closes #107