### PR TITLE
fix: incompatibility with rstest parametrized tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ http-body-util = "0.1"
 hyper-tls = "0.6"
 socket2 = "0.5.10"
 reqwest = "0.12.22"
+rstest = "0.26.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/src/interface/verifier.rs
+++ b/src/interface/verifier.rs
@@ -17,6 +17,11 @@ impl Drop for CallCountVerifier {
     fn drop(&mut self) {
         if let CallCountVerifier::WithCount { counter, expected } = self {
             let call_times = counter.load(Ordering::SeqCst);
+
+            // Because the counter is static, there's a possibility it might be reused in certain
+            // environments that don't know about injectorpp. Because of this, it is reset here.
+            counter.store(0, Ordering::SeqCst);
+
             if call_times != *expected {
                 // Avoid double panic
                 if std::thread::panicking() {

--- a/tests/rstest.rs
+++ b/tests/rstest.rs
@@ -1,0 +1,24 @@
+//! Tests that injectorpp is compatible with rstest
+
+use injectorpp::interface::injector::*;
+use rstest::rstest;
+
+fn foo(input: usize) -> usize {
+    input
+}
+
+#[rstest]
+#[case(0)]
+#[case(1)]
+fn test_multiple_cases(#[case] x: usize) {
+    let mut injector = InjectorPP::new();
+    injector
+        .when_called(injectorpp::func!(fn (foo)(usize) -> usize))
+        .will_execute(injectorpp::fake!(
+            func_type: fn(input: usize) -> usize,
+            returns: input + 1,
+            times: 1
+        ));
+
+    assert_eq!(foo(x), x + 1);
+}


### PR DESCRIPTION
[rstest](https://docs.rs/rstest/latest/rstest) generates parametrized tests ([`#[case]`](https://docs.rs/rstest/latest/rstest/attr.rstest.html#test-parametrized-cases)) as one helper function that is called by each test generated for the different cases. Because of this, injectorpp's internal static counter is reused between these test cases. The same would hold true for an injector created in any helper function.

This patch resets the static counter to zero when the verifier is dropped so it can be reused in these scenarios.

Additionally:
* [rstest](https://docs.rs/rstest/latest/rstest) is added as a dev dependency
* An new test validates the desired behavior
